### PR TITLE
Fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 OBJ = monsters.o m.o save.o jump.o display.o icon.o game.o read.o help.o fall.o scores.o edit.o encrypt.o
 
 CFLAGS ?= -O -s
+CFLAGS += -std=c99 -Wall -Wextra
 LIBS = -lncurses 
 CC ?= cc
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ OBJ = monsters.o m.o save.o jump.o display.o icon.o game.o read.o help.o fall.o 
 
 CFLAGS ?= -O -s
 CFLAGS += -std=c99 -Wall -Wextra
+CPPFLAGS += -D_POSIX_C_SOURCE=199309L
 LIBS = -lncurses 
 CC ?= cc
 

--- a/display.c
+++ b/display.c
@@ -183,7 +183,7 @@ void redraw_screen(bell,maxmoves,num,score,nf,diamonds,mx,sx,sy,frow)
     move(1,48);
     (void) addstr("\tFound\tTotal");
     move(3,48);
-    (void) sprintf(buffer,"%d\t %d\t %d  ",score,nf,diamonds);
+    (void) sprintf(buffer,"%ld\t %d\t %d  ",score,nf,diamonds);
     (void) addstr(buffer);
     if(! edit_mode) {
         move(6,48);

--- a/edit.c
+++ b/edit.c
@@ -1,5 +1,9 @@
 /* File edit.c */
 
+#include <errno.h>
+#include <stdlib.h>
+#include <strings.h>
+#include <unistd.h>
 #include "wand_head.h"
 
 extern char *playscreen();
@@ -41,7 +45,7 @@ static char *inst[] = { "    O  Boulder",
 *                    exit and player numbers,            *
 *                    hanging boulders/arrows etc         *
 **********************************************************/
-check_legality()
+void check_legality()
 {
 int ercount,cages,hanging,bmons,tele,arrival,you,mons,exits;
 int x, y;
@@ -158,7 +162,7 @@ void readstring(str,size)
   }
 }
 
-clearbottom()
+void clearbottom()
 {
 move(20,0);
 addstr("                                                                            \n");
@@ -202,7 +206,7 @@ clearbottom();
 *          screen_save          *
 *  save and restore screen data *
 *********************************/
-screen_save(maxmoves)
+void screen_save(maxmoves)
 int maxmoves;
 {
 char file[90];
@@ -223,11 +227,11 @@ move(20,0);
 addstr("                                                                           "); refresh();
 oldname = edit_screen;
 if( file[0] ) edit_screen = file;
-for(y = 0; y<=NOOFROWS;y++)        /* make sure screen written */
+for(y = 0; y<NOOFROWS;y++)        /* make sure screen written */
     if(screen[y][ROWLEN-1] == ' ') /* correctly...             */
         screen[y][ROWLEN-1] = '-';
 wscreen(0,maxmoves);
-for(y = 0; y<=NOOFROWS;y++)
+for(y = 0; y<NOOFROWS;y++)
     if(screen[y][ROWLEN-1] == '-')
         screen[y][ROWLEN-1] = ' ';
 edit_screen = oldname;
@@ -236,7 +240,7 @@ edit_screen = oldname;
 /*********************************************
 *                 screen_read                *
 **********************************************/
-screen_read(maxmoves)
+void screen_read(maxmoves)
     int *maxmoves;
 {
     static char file[90];
@@ -254,7 +258,7 @@ screen_read(maxmoves)
     if( ! file[0] ) return;
     edit_screen = file;
     rscreen(0,maxmoves);
-    for(y = 0; y<=NOOFROWS;y++)
+    for(y = 0; y<NOOFROWS;y++)
         if(screen[y][ROWLEN-1] == '-')
             screen[y][ROWLEN-1] = ' ';
 }
@@ -264,7 +268,7 @@ screen_read(maxmoves)
 *              edit_save             *
 *  save and restore edit memory data *
 **************************************/
-edit_save()
+void edit_save()
 {
     char file[90];
     int i = 0,fd;
@@ -286,7 +290,7 @@ edit_save()
 /*******************************************
 *                edit_restore              *
 ********************************************/
-edit_restore()
+void edit_restore()
 {
 char file[90];
 int i = 0,fd;
@@ -417,7 +421,11 @@ while(!quit)
         move(21,0);
         addstr("How many moves for this screen? :");
         refresh();echo();
-        scanf("%d",&maxmoves);noecho();
+        if (scanf("%d",&maxmoves) == EOF && errno != 0) {
+            fprintf(stderr, "scanf error\n");
+            exit(EXIT_FAILURE);
+        }
+        noecho();
         if(maxmoves < 0 ) maxmoves = 0;
         if(maxmoves != 0)
             (void) sprintf(buffer,"Moves   : %d        ",maxmoves);

--- a/encrypt.c
+++ b/encrypt.c
@@ -1,11 +1,13 @@
 /* File encrypt.c */
 
+#include <stdlib.h>
+#include <unistd.h>
 #include "wand_head.h"
 
 /* Uses seeded random xor to encrypt because setkey doesnt work on our
    system.                                                                 */
 
-crypt_file(name)
+void crypt_file(name)
 char *name;
 {
 char buffer[1024];

--- a/fall.c
+++ b/fall.c
@@ -2,6 +2,7 @@
 
 #include "wand_head.h"
 
+int bang(int x, int y, int *mx, int *my, int sx, int sy, char *howdead);
 extern void draw_symbol();
 extern int debug_disp;
 extern char screen[NOOFROWS][ROWLEN+1];

--- a/game.c
+++ b/game.c
@@ -1,5 +1,7 @@
 /* File game.c */
 
+#include <stdlib.h>
+#include <unistd.h>
 #include "wand_head.h"
 
 extern int move_monsters();
@@ -150,7 +152,11 @@ char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
          default:
               ch = getch();
         }
-        if((record_file != -1)&&(ch != 'q')) write(record_file,&ch,1);
+        if((record_file != -1)&&(ch != 'q'))
+            if (write(record_file,&ch,1) == -1) {
+                fprintf(stderr, "write error\n");
+                exit(EXIT_FAILURE);
+            }
         
         nx=x;
         ny=y;
@@ -380,7 +386,7 @@ char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
         #endif
             case ':': *score+=1;
                 move(3,48);
-                sprintf(buffer,"%d\t %d",*score,nf);
+                sprintf(buffer,"%ld\t %d",*score,nf);
                 (void) addstr(buffer);
             case ' ':
                 screen[y][x] = ' ';
@@ -411,7 +417,7 @@ char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
                     mx = my = -1;
                     *score+=100;
                     move(3,48);
-                    sprintf(buffer,"%d\t %d\t %d ",*score,nf,diamonds);
+                    sprintf(buffer,"%ld\t %d\t %d ",*score,nf,diamonds);
                     (void) addstr(buffer);
                     draw_symbol(50,11,' ');
                     move(12,56); addstr("              ");
@@ -494,7 +500,7 @@ char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
                     mx = my = -1;
                     *score+=100;
                     move(3,48);
-                    sprintf(buffer,"%d\t %d\t %d ",*score,nf,diamonds);
+                    sprintf(buffer,"%ld\t %d\t %d ",*score,nf,diamonds);
                     (void) addstr(buffer);
                     draw_symbol(50,11,' ');
                        move(12,56); addstr("              ");
@@ -542,7 +548,7 @@ char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
                     mx = my = -1;
                     *score+=100;
                     move(3,48);
-                    sprintf(buffer,"%d\t %d\t %d ",*score,nf,diamonds);
+                    sprintf(buffer,"%ld\t %d\t %d ",*score,nf,diamonds);
                     (void) addstr(buffer);
                     draw_symbol(50,11,' ');
                        move(12,56); addstr("              ");
@@ -616,7 +622,7 @@ char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
                     sy = y;
                     *score += 20;
                     move(3,48);
-                    sprintf(buffer,"%d\t %d\t %d ",*score,nf,diamonds);
+                    sprintf(buffer,"%ld\t %d\t %d ",*score,nf,diamonds);
                     (void) addstr(buffer);
                     if(!debug_disp)
                         display(sx,sy,frow,*score);

--- a/jump.c
+++ b/jump.c
@@ -1,5 +1,8 @@
 /* File jump.c */
 
+#include <errno.h>
+#include <stdlib.h>
+#include <time.h>
 #include "wand_head.h"
 
 extern int debug_disp;
@@ -24,7 +27,10 @@ char *passwd;
                 return 0;
         fseek(fp,position,ftell(fp));
         while(fgetc(fp) != '\n');
-        fscanf(fp,"%s\n",passwd);
+        if (fscanf(fp,"%s\n",passwd) == EOF && errno != 0) {
+            fprintf(stderr, "fscanf error\n");
+            exit(EXIT_FAILURE);
+        }
         /* read a word into passwd */
         fclose(fp);
         return (1);
@@ -36,11 +42,8 @@ char *passwd;
 void showpass(num)
      int num;
 {
-    long position;
     char correct[20];
     char buffer[100];
-    FILE *fp;
-    char ch;
     if(no_passwords)
         return;
     if(!debug_disp)
@@ -53,7 +56,7 @@ void showpass(num)
     addstr(buffer);
     addstr("PRESS ANY KEY TO REMOVE IT AND CONTINUE                          \n");
     refresh();
-    ch = getch();
+    getch();
     if(!debug_disp)
         move(18,0);
     else
@@ -76,10 +79,9 @@ int jumpscreen(num)
     char word[20],
          buffer[100],
          correct[20];
-    int index=0, input;
-    char ch;
-    long position;
-    int  fp, scrn;
+    int index=0;
+    int scrn;
+    struct timespec t;
 
     if(no_passwords == 1) {
         if(!debug_disp)
@@ -183,7 +185,9 @@ int jumpscreen(num)
         move(18,0);
     addstr("PASSWORD NOT RECOGNISED!                    ");
     refresh();
-    usleep(750000);  /* Marina */
+    t.tv_sec = 0;
+    t.tv_nsec = 750000000;
+    nanosleep(&t, NULL);
     if(!debug_disp)
         move(16,0);
     else

--- a/monsters.c
+++ b/monsters.c
@@ -1,5 +1,6 @@
 /* File monsters.c */
 
+#include <stdlib.h>
 #include "wand_head.h"
 
 typedef struct { int d[2]; } direction;
@@ -31,7 +32,6 @@ extern struct mon_rec start_of_list;
 struct mon_rec *make_monster(x,y)
 int x,y;
 {
-    /* char *malloc(); */
     #define MALLOC (struct mon_rec *)malloc(sizeof(struct mon_rec))
     struct mon_rec *monster;
     if(tail_of_list->next == NULL)
@@ -98,7 +98,6 @@ int move_monsters(mxp, myp, score, howdead, sx, sy, nf, bell, x, y, diamonds)
 {
     int xdirection, ydirection, hd, vd;
     int deadyet = 0;
-    int bx, by, nbx, nby, tmpx,tmpy;
     direction new_disp;
     struct mon_rec *monster,*current;
     char buffer[25];
@@ -151,7 +150,7 @@ int move_monsters(mxp, myp, score, howdead, sx, sy, nf, bell, x, y, diamonds)
 == ' ')||(screen[*myp+ydirection][*mxp] == '@')))
                 *myp+=ydirection;
             else
-                if(((*mxp+xdirection)<ROWLEN)&&(screen[*myp][*mxp+xdirection] == ' ')||(screen[*myp][*mxp+xdirection] == '@'))
+                if((((*mxp+xdirection)<ROWLEN)&&(screen[*myp][*mxp+xdirection] == ' '))||(screen[*myp][*mxp+xdirection] == '@'))
             *mxp+=xdirection;
         }
         if(!debug_disp)

--- a/read.c
+++ b/read.c
@@ -1,5 +1,9 @@
 /* File read.c */
 
+#include <sys/types.h>
+#include <err.h>
+#include <stdlib.h>
+#include <unistd.h>
 #include "wand_head.h"
 
 extern int inform_me();
@@ -44,12 +48,18 @@ int *maxmoves, num;
     {
         for(y = 0;y<NOOFROWS;y++)
         {
-            fgets(*row_ptr,ROWLEN + 2,fp);
+            if (fgets(*row_ptr,ROWLEN + 2,fp) == NULL) {
+                fprintf(stderr, "fgets error\n");
+                exit(EXIT_FAILURE);
+            }
             numr = strlen( *row_ptr ) - 1;
             while(numr < ROWLEN) (*row_ptr)[numr++] = ' ';
             row_ptr++;
         };
-        fgets(screen_name,60,fp);
+        if (fgets(screen_name,60,fp) == NULL) {
+            fprintf(stderr, "fgets error\n");
+            exit(EXIT_FAILURE);
+        }
         screen_name[61] = '\0';
         screen_name[strlen(screen_name)-1] = '\0';
         if(fscanf(fp,"%d",maxmoves) != 1)

--- a/save.c
+++ b/save.c
@@ -1,7 +1,9 @@
 /* File save.c */
 
-#include "wand_head.h"
 #include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "wand_head.h"
 
 extern char screen[NOOFROWS][ROWLEN+1];
 extern int saved_game;
@@ -116,8 +118,6 @@ void restore_game(num, score, bell, maxmoves)
     struct        saved_game        s;
     struct        mon_rec        *mp, *tmp, tmp_monst;
     char        fname[128], *fp;
-    char        *m_terminate = NULL;
-    FILE        *fo;
     extern        char        *getenv();
 
     if ((char *)NULL == (fp = getenv("SAVENAME")))
@@ -127,9 +127,10 @@ void restore_game(num, score, bell, maxmoves)
         refresh();
         echo(); CBOFF;
         fp = fname;
-        fgets(fp,sizeof(fname),stdin); /* Marina Brown */
-        m_terminate=strchr(fp,'\n');
-        m_terminate="\0";           /* End Marina delta */
+        if (fgets(fp,sizeof(fname),stdin) == NULL) { /* Marina Brown */
+            fprintf(stderr, "fgets error\n");
+            exit(EXIT_FAILURE);
+        }
         CBON; noecho();
     }
     clear();

--- a/wand_head.h
+++ b/wand_head.h
@@ -37,8 +37,8 @@
 
 /* To disable the recording of hiscores from games restored from saves         */
 /* #define NO_RESTORED_GAME_HISCORES  */
-/* #define COMPARE_BY_NAME  /* define this to compare by name, not uid         */
-/* #define NO_ENCRYPTION /* define this to disable the savefile encryptor */
+/* #define COMPARE_BY_NAME  // define this to compare by name, not uid         */
+/* #define NO_ENCRYPTION // define this to disable the savefile encryptor */
 #define NOISY    /* do we want bells in the game ? */
 
                 /****** OTHER PARAMETERS ******/
@@ -138,6 +138,9 @@ extern  void editscreen(int ,int *,int *,int ,char *);
 extern  int check(int *,int *,int ,int ,int ,int ,int ,int ,char *);
 extern  int fall(int *,int *,int ,int ,int ,int ,char *);
 
+/* HELP.C */
+extern  void helpme();
+
 /* GAME.C */
 extern  struct mon_rec *make_monster(int ,int );
 extern  char *playscreen(int *,int *,int *,int ,char *);
@@ -162,7 +165,7 @@ extern  void restore_game(int *,int *,int *,int *,struct mon_rec *,struct mon_re
 /* SCORES.C */
 extern  int savescore(char *,int ,int ,char *);
 extern  void delete_entry(int );
-extern  int erase_scores(void);
+extern  void erase_scores(void);
 
 #else
 
@@ -178,6 +181,9 @@ extern  void editscreen();
 /* FALL.C */
 extern  int check();
 extern  int fall();
+
+/* HELP.C */
+extern  void helpme();
 
 /* GAME.C */
 extern  struct mon_rec *make_monster();
@@ -203,7 +209,7 @@ extern  void restore_game();
 /* SCORES.C */
 extern  int savescore();
 extern  void delete_entry();
-extern  int erase_scores();
+extern  void erase_scores();
 
 #endif
 


### PR DESCRIPTION
Only two remain, unused variables, which are function parameters. So I just left them alone.

This fix definitely would break DOS compatibility, such as the use of `nanosleep`.

I haven't touched the K&R style part, might do it after this one is merged.
