### PR TITLE
Flexible installation, uses screens in current directory, indent for code style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 # and yet again by adb@bucsf.bu.edu
 # Make clean - Marina Brown marina@surferz.net 2001,2
 
+PROGRAM = wanderer
+
 TOOLS = convert passwords
 SRC_TOOLS = $(addsuffix .c,$(TOOLS))
 
@@ -16,10 +18,31 @@ CFLAGS   += -std=c99 -Wall -Wextra
 CPPFLAGS += -D_POSIX_C_SOURCE=199309L
 LDLIBS   += -lncurses 
 
-all: wanderer
+INSTALL      = install
+INSTALL_BIN  = $(INSTALL) -D -m 755
+INSTALL_DATA = $(INSTALL) -D -m 644
+INSTALL_MAN  = $(INSTALL) -D -m 644
+
+PREFIX    = /usr/local
+BIN_DIR   = $(PREFIX)/bin
+SHARE_DIR = $(PREFIX)/share
+MAN_DIR   = $(PREFIX)/share/man
+MAN1_DIR  = $(MAN_DIR)/man1
+MAN6_DIR  = $(MAN_DIR)/man6
+
+WANDERERPATH = $(SHARE_DIR)/wanderer
+SCREENPATH   = $(SHARE_DIR)/wanderer/screens
+HISCOREPATH  = $(SHARE_DIR)/wanderer/hiscore
+
+CPPFLAGS += -DPREFIX=$(PREFIX)                 \
+	    -DSCREENPATH='"$(SCREENPATH)"'     \
+	    -DHISCOREPATH='"$(HISCOREPATH)"'
+
+
+all: $(PROGRAM)
 .PHONY: all
 
-wanderer: $(OBJS)
+$(PROGRAM): $(OBJS)
 
 convert: CPPFLAGS += -D__CONVERT
 convert: convert.c encrypt.c encrypt.h
@@ -31,17 +54,14 @@ passwords: passwords.c
 %.o: %.c %.h wand_head.h
 
 install: 
-	mkdir /usr/local/share/wanderer
-	mkdir /usr/local/share/wanderer/screens
-	cp screens/* /usr/local/share/wanderer/screens
-	touch /usr/local/share/wanderer/hiscore
-	chown root.game /usr/local/share/wanderer/hiscore
-	chmod g+w /usr/local/share/wanderer/hiscore
-	cp wanderer /usr/local/bin
-	chown root.game /usr/local/bin/wanderer
-	chmod +x /usr/local/bin/wanderer
-	chmod g+s /usr/local/bin/wanderer
-	cp wanderer.6 /usr/share/man/man6
+	$(INSTALL_DATA) -t $(SCREENPATH) screens/*
+	touch $(HISCOREPATH)
+	[ $(USER) = root ] && chown root:games $(HISCOREPATH) || true
+	[ $(USER) = root ] && chmod g+w $(HISCOREPATH) || true
+	$(INSTALL_BIN) $(PROGRAM) $(BIN_DIR)/$(PROGRAM)
+	[ $(USER) = root ] && chown root:games $(BIN_DIR)/$(PROGRAM) || true
+	[ $(USER) = root ] && chmod g+s $(BIN_DIR)/$(PROGRAM) || true
+	$(INSTALL_MAN) wanderer.6 $(MAN6_DIR)
 .PHONY: install
 
 clean:
@@ -55,7 +75,7 @@ distclean:
 .PHONY: distclean
 
 uninstall:
-	$(RM)    /usr/local/bin/wanderer
-	$(RM) -r /usr/local/share/wanderer/
-	$(RM)    /usr/share/man/man6/wanderer.6
+	$(RM)    $(BIN_DIR)/$(PROGRAM)
+	$(RM) -r $(WANDERERPATH)
+	$(RM)    $(MAN6_DIR)wanderer.6
 .PHONY: uninstall

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ OBJS = $(patsubst %.c,%.o,$(SRCS))
 CC       ?= cc
 CFLAGS   ?= -O -s
 CFLAGS   += -std=c99 -Wall -Wextra
-CPPFLAGS += -D_POSIX_C_SOURCE=199309L
+CPPFLAGS += -D_POSIX_C_SOURCE=200809L
 LDLIBS   += -lncurses 
 
 INSTALL      = install

--- a/convert.c
+++ b/convert.c
@@ -37,25 +37,25 @@
 /**********************************************
 *          variable declarations              *
 ***********************************************/
-char screen[NOOFROWS][ROWLEN+1];
-char screen_name[ROWLEN+1];
+char screen[NOOFROWS][ROWLEN + 1];
+char screen_name[ROWLEN + 1];
 char *infile, *outfile;
 
 struct saved_game
 {
-    short   num;
-    long    score;
-    short   bell;
-    short   maxmoves;
-    short   num_monsters;
+    short num;
+    long score;
+    short bell;
+    short maxmoves;
+    short num_monsters;
 };
 
-struct    save_vars    zz;
-struct  old_save_vars   yy;
+struct save_vars zz;
+struct old_save_vars yy;
 
 int num, bell, maxmoves;
 long score;
-struct mon_rec  *last_of_list, *start_of_list, *tail_of_list;
+struct mon_rec *last_of_list, *start_of_list, *tail_of_list;
 
 int o_enc, n_enc;
 int verbose;
@@ -67,10 +67,10 @@ struct mon_rec *make_monster(int x, int y)
 {
 #define MALLOC (struct mon_rec *)malloc(sizeof(struct mon_rec))
     struct mon_rec *monster;
-    if(tail_of_list->next == NULL)
+    if (tail_of_list->next == NULL)
     {
-        if((last_of_list = MALLOC) == NULL)
-        return NULL;
+        if ((last_of_list = MALLOC) == NULL)
+            return NULL;
         tail_of_list->next = last_of_list;
         last_of_list->prev = tail_of_list;
         last_of_list->next = NULL;
@@ -78,7 +78,7 @@ struct mon_rec *make_monster(int x, int y)
     monster = tail_of_list = tail_of_list->next;
     monster->x = x;
     monster->y = y;
-    monster->mx = 1;      /* always start moving RIGHT. (fix later)  */
+    monster->mx = 1;            /* always start moving RIGHT. (fix later)  */
     monster->my = 0;
     monster->under = ' ';
     return monster;
@@ -89,15 +89,16 @@ struct mon_rec *make_monster(int x, int y)
 **************************************************/
 void save_game()
 {
-    char    fname[128], *fp;
-    FILE    *fo;
-    struct    saved_game    s;
-    extern    char    *getenv();
-    struct    mon_rec    *mp;
+    char fname[128], *fp;
+    FILE *fo;
+    struct saved_game s;
+    extern char *getenv();
+    struct mon_rec *mp;
 
     fp = outfile;
 
-    if ((FILE *)NULL == (fo = fopen(outfile, W_BIN))) {
+    if ((FILE *) NULL == (fo = fopen(outfile, W_BIN)))
+    {
         perror(fp);
         exit(1);
     }
@@ -108,15 +109,16 @@ void save_game()
     s.maxmoves = maxmoves;
     s.num_monsters = 0;
 
-    mp = start_of_list;        /* first entry is dummy    */
-    while (mp != tail_of_list) {
+    mp = start_of_list;         /* first entry is dummy    */
+    while (mp != tail_of_list)
+    {
         mp = mp->next;
-        s.num_monsters++;    /* count them monsters    */
+        s.num_monsters++;       /* count them monsters    */
     }
 
-    if ( (1 != fwrite((char *)&s, sizeof(s), 1, fo)) ||
-         (1 != fwrite((char *)screen, sizeof(screen), 1, fo)) ||
-         (1 != fwrite((char *)&zz, sizeof(zz), 1, fo)) )
+    if ((1 != fwrite((char *) &s, sizeof(s), 1, fo))
+        || (1 != fwrite((char *) screen, sizeof(screen), 1, fo))
+        || (1 != fwrite((char *) &zz, sizeof(zz), 1, fo)))
     {
         printf("Write error on '%s'\n", fname);
         fclose(fo);
@@ -125,20 +127,22 @@ void save_game()
     }
 
     mp = start_of_list;
-    while (mp != tail_of_list) {
+    while (mp != tail_of_list)
+    {
         /* save them monsters    */
         mp = mp->next;
-        if (1 != fwrite((char *)mp, sizeof(struct mon_rec), 1, fo)) {
+        if (1 != fwrite((char *) mp, sizeof(struct mon_rec), 1, fo))
+        {
             printf("Write error on '%s'\n", fname);
             fclose(fo);
             unlink(fname);
             exit(1);
         }
     }
-    fwrite(screen_name,sizeof(char),strlen(screen_name),fo);
+    fwrite(screen_name, sizeof(char), strlen(screen_name), fo);
     fclose(fo);
-    if( n_enc )
-        crypt_file(outfile);   /* encrpyt the saved game */
+    if (n_enc)
+        crypt_file(outfile);    /* encrpyt the saved game */
     printf("Game saved.\n\nWanderer Copyright (C) 1988 S Shipway\n\n");
 }
 
@@ -154,16 +158,18 @@ void restore_game()
 
     fp = infile;
 
-    if( o_enc )
-         crypt_file(infile);   /* decrypt it */
-    if ((FILE *)NULL == (fi = fopen(infile, R_BIN))) {
+    if (o_enc)
+        crypt_file(infile);     /* decrypt it */
+    if ((FILE *) NULL == (fi = fopen(infile, R_BIN)))
+    {
         printf("Open error on '%s'\n", fp);
         printf("Cannot restore game --- sorry.\n");
         exit(1);
     }
-    if ( (1 != fread((char *)&s, sizeof(s), 1, fi)) ||
-         (1 != fread((char *)screen, sizeof(screen), 1, fi)) ||
-         (1 != fread((char *)&yy, sizeof(yy), 1, fi)) ) {
+    if ((1 != fread((char *) &s, sizeof(s), 1, fi))
+        || (1 != fread((char *) screen, sizeof(screen), 1, fi))
+        || (1 != fread((char *) &yy, sizeof(yy), 1, fi)))
+    {
         printf("Read error on '%s'\n", fp);
         printf("Cannot restore game --- sorry.\n");
         fclose(fi);
@@ -177,7 +183,8 @@ void restore_game()
 
     /* free any monsters already on chain, to start clean */
     mp = start_of_list->next;
-    while ((mp != NULL) && (mp != start_of_list)) {
+    while ((mp != NULL) && (mp != start_of_list))
+    {
         /* free them monsters    */
         tmp = mp;
         mp = mp->next;
@@ -191,31 +198,34 @@ void restore_game()
     start_of_list->mx = 0;
     start_of_list->my = 0;
     start_of_list->under = 0;
-    start_of_list->next = (struct mon_rec *)NULL;
-    start_of_list->prev = (struct mon_rec *)NULL;
+    start_of_list->next = (struct mon_rec *) NULL;
+    start_of_list->prev = (struct mon_rec *) NULL;
 
     tail_of_list = start_of_list;
 
-    while (s.num_monsters--) {
+    while (s.num_monsters--)
+    {
         /* use make_monster to allocate the monster structures    */
         /* to get all the linking right without even trying    */
-        if ((struct mon_rec *)NULL == (mp = make_monster(0, 0))) {
+        if ((struct mon_rec *) NULL == (mp = make_monster(0, 0)))
+        {
             printf("Monster alloc error on '%s'\n", fp);
             printf("Try again - it might work.\nBut then,pigs might fly...\n");
             fclose(fi);
             exit(1);
         }
-        if (1 != fread((char *)&tmp_monst, sizeof(struct mon_rec), 1, fi)) {
+        if (1 != fread((char *) &tmp_monst, sizeof(struct mon_rec), 1, fi))
+        {
             printf("Monster read error on '%s'\n", fp);
             printf("Cannot restore game --- sorry.\n");
             fclose(fi);
             exit(1);
         }
         /* copy info without trashing links    */
-        mp->x     = tmp_monst.x;
-        mp->y     = tmp_monst.y;
-        mp->mx    = tmp_monst.mx;
-        mp->my    = tmp_monst.my;
+        mp->x = tmp_monst.x;
+        mp->y = tmp_monst.y;
+        mp->mx = tmp_monst.mx;
+        mp->my = tmp_monst.my;
         mp->under = tmp_monst.under;
     }
     fclose(fi);
@@ -224,7 +234,7 @@ void restore_game()
 /*************************************************************
 *         external globals - move to top  Marina             *
 **************************************************************/
-extern int opterr,optind;
+extern int opterr, optind;
 extern char *optarg;
 
 /**************************************************************
@@ -244,24 +254,38 @@ int main(int argc, char **argv)
     o_enc = n_enc = 1;
 #endif
 
-    while( ( c = getopt(argc,argv,"CNcnv") ) != -1 )
-    switch ( c ) 
-    {
-        case 'C': o_enc = 1; break;
-        case 'c': n_enc = 1; break;
-        case 'N': o_enc = 0; break;
-        case 'n': n_enc = 0; break;
-        case 'v': verbose = 1; break;
-        default : printf("Usage: %s [ -v ] [ -C | -c ] [ -N | -n ] oldfile newfile\n",argv[0]);
+    while ((c = getopt(argc, argv, "CNcnv")) != -1)
+        switch (c)
+        {
+        case 'C':
+            o_enc = 1;
+            break;
+        case 'c':
+            n_enc = 1;
+            break;
+        case 'N':
+            o_enc = 0;
+            break;
+        case 'n':
+            n_enc = 0;
+            break;
+        case 'v':
+            verbose = 1;
+            break;
+        default:
+            printf
+                ("Usage: %s [ -v ] [ -C | -c ] [ -N | -n ] oldfile newfile\n",
+                 argv[0]);
             printf("-v : verbose\n");
             printf("-C : file is encrypted\n -N : file not encrypted\n");
             printf("Upper case -- old file, lower case -- new file\n");
             exit(1);
-    }
+        }
 
-    if( (argc - optind) < 2 )
+    if ((argc - optind) < 2)
     {
-        printf("Usage: %s [ -v ] [ -C | -c ] [ -N | -n ] oldfile newfile\n",argv[0]);
+        printf("Usage: %s [ -v ] [ -C | -c ] [ -N | -n ] oldfile newfile\n",
+               argv[0]);
         printf("-v : verbose\n");
         printf("-C : file is encrypted\n -N : file not encrypted\n");
         printf("Upper case -- old file, lower case -- new file\n");
@@ -269,24 +293,29 @@ int main(int argc, char **argv)
     }
 
 
-    infile = argv[optind++]; outfile = argv[optind];
-    if(verbose) printf("Converting %s to %s.\n",infile,outfile);
+    infile = argv[optind++];
+    outfile = argv[optind];
+    if (verbose)
+        printf("Converting %s to %s.\n", infile, outfile);
 
-    if(verbose )
+    if (verbose)
     {
-        printf( "Reading in file %s. ", infile);
-        if( o_enc ) printf("(encrypted)");
+        printf("Reading in file %s. ", infile);
+        if (o_enc)
+            printf("(encrypted)");
         printf("\n");
     }
 
     restore_game();
 
-    if( verbose ) printf("Giving screen name.\n");
+    if (verbose)
+        printf("Giving screen name.\n");
 
-    sprintf(screen_name,"------ Wanderer version %s ------",VERSION);
+    sprintf(screen_name, "------ Wanderer version %s ------", VERSION);
 
-    if( verbose ) printf(" Copying struct variables... \n");
-    
+    if (verbose)
+        printf(" Copying struct variables... \n");
+
     zz.z_x = yy.z_x;
     zz.z_y = yy.z_y;
     zz.z_tx = yy.z_tx;
@@ -298,10 +327,11 @@ int main(int argc, char **argv)
     zz.z_diamonds = yy.z_diamonds;
     zz.z_nf = yy.z_nf;
 
-    if(verbose)
+    if (verbose)
     {
-        printf( "Saving to file %s. ", outfile);
-        if( n_enc ) printf("(encrypted)");
+        printf("Saving to file %s. ", outfile);
+        if (n_enc)
+            printf("(encrypted)");
         printf("\n");
     }
 

--- a/display.c
+++ b/display.c
@@ -62,7 +62,7 @@ void map(char (*row_ptr)[ROWLEN + 1])
         refresh();
         getchar();
         move(18, 0);
-        addstr("                                    ");
+        printw("%36s", "");
         refresh();
         for (y = 0; y <= (NOOFROWS + 1); y++)
         {
@@ -138,7 +138,7 @@ void showname()
     move(19, 0);
     if ((screen_name[0] == '#') || (screen_name[0] == '\0'))
     {
-        addstr("Unnamed screen.                         ");
+        printw("%-40s", "Unnamed screen.");
     }
     else
         addstr(screen_name);
@@ -203,15 +203,15 @@ void redraw_screen(int *bell, int maxmoves, int num, long score, int nf,
         move(12, 56);
         addstr("Monster on the");
         move(13, 56);
-        addstr("loose!        ");
+        printw("%-14s", "loose!");
     }
     else
     {
         draw_symbol(50, 11, ' ');
         move(12, 56);
-        addstr("              ");
+        printw("%14s", "");
         move(13, 56);
-        addstr("              ");
+        printw("%14s", "");
     }
 
     showname();
@@ -245,8 +245,7 @@ int inform_me(char *s, int qable)
     if (getch() == 'q')
         retval = 1;
     move(20, 0);
-    addstr
-        ("                                                                             ");
+    printw("%77s", "");
     refresh();
     return (retval);
 }

--- a/display.c
+++ b/display.c
@@ -19,56 +19,55 @@ extern char *edit_memory, *memory_end;
 /******************************************
 *                   map                   *
 *******************************************/
-void map(char (*row_ptr)[ROWLEN+1])
+void map(char (*row_ptr)[ROWLEN + 1])
 {
-    int  x,y;
+    int x, y;
     char ch;
 
-    move(0,0);
+    move(0, 0);
     addch('+');
-    for(x = 0;x < ROWLEN; x++)
+    for (x = 0; x < ROWLEN; x++)
         addch('-');
     addch('+');
-    for(y = 0;y < NOOFROWS; y++)
+    for (y = 0; y < NOOFROWS; y++)
     {
-        move(y+1,0);
+        move(y + 1, 0);
         addch('|');
-        for(x = 0; x < ROWLEN; x++)
+        for (x = 0; x < ROWLEN; x++)
         {
             ch = (*row_ptr)[x];
-            if(!debug_disp)
+            if (!debug_disp)
             {
-                if((ch == 'M')||(ch == 'S'))
+                if ((ch == 'M') || (ch == 'S'))
                     ch = ' ';
                 addch(ch);
             }
+            else if (ch != '\0')
+                addch(ch);
             else
-                if(ch!='\0')
-                    addch(ch);
-                else
-                    addch('"');
+                addch('"');
         }
         addch('|');
         row_ptr++;
     }
-    move(y+1,0);
+    move(y + 1, 0);
     addch('+');
-    for(x = 0;x < ROWLEN; x++)
+    for (x = 0; x < ROWLEN; x++)
         addch('-');
     addch('+');
-    if(!debug_disp)
+    if (!debug_disp)
     {
-        move(18,0);
+        move(18, 0);
         addstr("Press any key to return to the game.");
         refresh();
         getchar();
-        move(18,0);
+        move(18, 0);
         addstr("                                    ");
         refresh();
-        for(y=0;y<=(NOOFROWS+1);y++)
+        for (y = 0; y <= (NOOFROWS + 1); y++)
         {
-            move(y,0);
-            for(x=0;x<=(ROWLEN+2);x++)
+            move(y, 0);
+            for (x = 0; x <= (ROWLEN + 2); x++)
                 addch(' ');
         }
     }
@@ -80,54 +79,54 @@ void map(char (*row_ptr)[ROWLEN+1])
 /***********************************************
 *                   display                    *
 ************************************************/
-void display(int cx, int cy, char (*row_ptr)[ROWLEN+1])
+void display(int cx, int cy, char (*row_ptr)[ROWLEN + 1])
 {
-    int  x,y = 0, x_coord,y_coord;
+    int x, y = 0, x_coord, y_coord;
     char ch;
-    while(y<(cy-3))
+    while (y < (cy - 3))
     {
         y++;
         row_ptr++;
     };
-    move(0,0);
+    move(0, 0);
     addstr("+---------------------------------+");
-    move(15,0);
+    move(15, 0);
     addstr("+---------------------------------+");
-    for(y=(cy-3);y<=(cy+3);y++)
+    for (y = (cy - 3); y <= (cy + 3); y++)
     {
-        y_coord = (y+3-cy)*2;
-        if ((y<0) || (y>=NOOFROWS))
+        y_coord = (y + 3 - cy) * 2;
+        if ((y < 0) || (y >= NOOFROWS))
         {
-            move(y_coord+1,0);
+            move(y_coord + 1, 0);
             addstr("|#################################|");
-            move(y_coord+2,0);
+            move(y_coord + 2, 0);
             addstr("|#################################|");
         }
         else
         {
-            move(y_coord+1,0);
+            move(y_coord + 1, 0);
             addch('|');
-            move(y_coord+1,34);
+            move(y_coord + 1, 34);
             addch('|');
-            move(y_coord+2,0);
+            move(y_coord + 2, 0);
             addch('|');
-            move(y_coord+2,34);
+            move(y_coord + 2, 34);
             addch('|');
-            for(x=(cx-5);x<=(cx+5);x++)
+            for (x = (cx - 5); x <= (cx + 5); x++)
             {
-                x_coord = (x+5-cx)*3;
-                if ((x<0) || (x>ROWLEN-1))
-                    draw_symbol(x_coord,y_coord,'#');
+                x_coord = (x + 5 - cx) * 3;
+                if ((x < 0) || (x > ROWLEN - 1))
+                    draw_symbol(x_coord, y_coord, '#');
                 else
                 {
                     ch = (*row_ptr)[x];
-                    draw_symbol(x_coord,y_coord,ch);
+                    draw_symbol(x_coord, y_coord, ch);
                 }
             };
             row_ptr++;
-        }                   /*   end if   */
-    }                       /* end y loop */
-    move(16,0);
+        }                       /*   end if   */
+    }                           /* end y loop */
+    move(16, 0);
     refresh();
 }
 
@@ -136,27 +135,27 @@ void display(int cx, int cy, char (*row_ptr)[ROWLEN+1])
 **************************************************************/
 void showname()
 {
-    move(19,0);
-    if(( screen_name[0] == '#' )||(screen_name[0] == '\0'))
+    move(19, 0);
+    if ((screen_name[0] == '#') || (screen_name[0] == '\0'))
     {
         addstr("Unnamed screen.                         ");
-    } 
+    }
     else
         addstr(screen_name);
-    if( edit_memory )
+    if (edit_memory)
     {
-        move(7,45);
+        move(7, 45);
         addstr("MEMORY: ( Start, ) End,");
-        move(8,53);
+        move(8, 53);
         addstr("* Play, & Extend.");
-        move(9,53);
+        move(9, 53);
         addstr("- Chkpt, + Cont.");
-        move(10,53);
-        if( memory_end == edit_memory )
+        move(10, 53);
+        if (memory_end == edit_memory)
         {
             addstr("--Empty--");
         }
-        else 
+        else
         {
             addstr("-Occupied-");
         }
@@ -167,45 +166,57 @@ void showname()
 /******************************************************************
 *                           redraw_screen                         *
 *******************************************************************/
-void redraw_screen(int *bell, int maxmoves, int num, long score, int nf, int diamonds, int mx, int sx, int sy, char (*frow)[ROWLEN+1])
+void redraw_screen(int *bell, int maxmoves, int num, long score, int nf,
+                   int diamonds, int mx, int sx, int sy,
+                   char (*frow)[ROWLEN + 1])
 {
     char buffer[50];
 
     clear();
-    move(0,48);
+    move(0, 48);
     addstr("Score\t   Diamonds");
-    move(1,48);
+    move(1, 48);
     addstr("\tFound\tTotal");
-    move(3,48);
-    sprintf(buffer,"%ld\t %d\t %d  ",score,nf,diamonds);
+    move(3, 48);
+    sprintf(buffer, "%ld\t %d\t %d  ", score, nf, diamonds);
     addstr(buffer);
-    if(! edit_mode) {
-        move(6,48);
-        sprintf(buffer,"Current screen %d",num);
+    if (!edit_mode)
+    {
+        move(6, 48);
+        sprintf(buffer, "Current screen %d", num);
         addstr(buffer);
     }
-    if(maxmoves != -1)
-        sprintf(buffer,"Moves remaining = %d   ",maxmoves);
+    if (maxmoves != -1)
+        sprintf(buffer, "Moves remaining = %d   ", maxmoves);
     else
-        strcpy(buffer,"     Unlimited moves     ");
-    move(15,48);
+        strcpy(buffer, "     Unlimited moves     ");
+    move(15, 48);
     addstr(buffer);
-    move(17,56);
-    if( *bell ) addstr("Bell ON ");
-    else addstr("Bell OFF");
-    if(mx != -1)  {                         /* tell player if monster exists */
-        draw_symbol(50,11,'M');
-        move(12,56); addstr("Monster on the");
-        move(13,56); addstr("loose!        ");
-    } else {
-        draw_symbol(50,11,' ');
-        move(12,56); addstr("              ");
-        move(13,56); addstr("              ");
+    move(17, 56);
+    if (*bell)
+        addstr("Bell ON ");
+    else
+        addstr("Bell OFF");
+    if (mx != -1)
+    {                           /* tell player if monster exists */
+        draw_symbol(50, 11, 'M');
+        move(12, 56);
+        addstr("Monster on the");
+        move(13, 56);
+        addstr("loose!        ");
+    }
+    else
+    {
+        draw_symbol(50, 11, ' ');
+        move(12, 56);
+        addstr("              ");
+        move(13, 56);
+        addstr("              ");
     }
 
     showname();
 
-    if(!debug_disp)
+    if (!debug_disp)
         display(sx, sy, frow);
     else
         map(frow);
@@ -217,7 +228,7 @@ void redraw_screen(int *bell, int maxmoves, int num, long score, int nf, int dia
 int inform_me(char *s, int qable)
 {
     int retval = 0;
-    move(20,0);
+    move(20, 0);
 #ifdef TVI
     addstr(TVI);
 #endif
@@ -228,12 +239,14 @@ int inform_me(char *s, int qable)
 #endif
     standend();
     addstr(" <MORE>");
-    if(qable)
+    if (qable)
         addstr(" (q stops)");
     refresh();
-    if( getch() == 'q' )
+    if (getch() == 'q')
         retval = 1;
-    move(20,0); addstr("                                                                             ");
+    move(20, 0);
+    addstr
+        ("                                                                             ");
     refresh();
-    return(retval);
+    return (retval);
 }

--- a/display.h
+++ b/display.h
@@ -19,9 +19,11 @@
 #define ROWLEN 40
 #define NOOFROWS 16
 
-void display(int cx, int cy, char (*row_ptr)[ROWLEN+1]);
+void display(int cx, int cy, char (*row_ptr)[ROWLEN + 1]);
 int inform_me(char *s, int qable);
-void map(char (*row_ptr)[ROWLEN+1]);
-void redraw_screen(int *bell, int maxmoves, int num, long score, int nf, int diamonds, int mx, int sx, int sy, char (*frow)[ROWLEN+1]);
+void map(char (*row_ptr)[ROWLEN + 1]);
+void redraw_screen(int *bell, int maxmoves, int num, long score,
+                   int nf, int diamonds, int mx, int sx, int sy,
+                   char (*frow)[ROWLEN + 1]);
 
 #endif // __DISPLAY_H

--- a/edit.c
+++ b/edit.c
@@ -15,31 +15,32 @@
 
 extern int debug_disp;
 extern char *edit_screen;
-extern char screen[NOOFROWS][ROWLEN+1];
+extern char screen[NOOFROWS][ROWLEN + 1];
 extern char *edit_memory;
 extern char *memory_end;
 extern char screen_name[61];
 
 static char *inst[] = { "    O  Boulder",
-                        "  < >  Arrows",
-                        "    ^  Balloon",
-                        "    :  Earth",
-                        "    !  Landmine",
-                        "    *  Treasure",
-                        "  / \\  Deflectors",
-                        "    +  Cage",
-                        "_ = #  Rock (# indestructable)",
-                        "    T  Teleport",
-                        "    A  Arrival (1 max)",
-                        "    X  Exit (always 1)",
-                        "    @  Start (always 1)",
-                        "    M  Big Monster (1 max)",
-                        "    S  Baby Monster",
-                        "    -  Alternative space",
-                        "    C  Time Capsule",
-                        "    ~  Thingy",
-                        "    B  Bomb",
-                        NULL };
+    "  < >  Arrows",
+    "    ^  Balloon",
+    "    :  Earth",
+    "    !  Landmine",
+    "    *  Treasure",
+    "  / \\  Deflectors",
+    "    +  Cage",
+    "_ = #  Rock (# indestructable)",
+    "    T  Teleport",
+    "    A  Arrival (1 max)",
+    "    X  Exit (always 1)",
+    "    @  Start (always 1)",
+    "    M  Big Monster (1 max)",
+    "    S  Baby Monster",
+    "    -  Alternative space",
+    "    C  Time Capsule",
+    "    ~  Thingy",
+    "    B  Bomb",
+    NULL
+};
 
 /*********************************************************
 *                      check_legality                    *
@@ -50,85 +51,144 @@ static char *inst[] = { "    O  Boulder",
 **********************************************************/
 void check_legality()
 {
-int ercount,cages,hanging,bmons,tele,arrival,you,mons,exits;
-int x, y;
-char buf[80];
-ercount = hanging = cages = bmons = tele = arrival = you = mons = exits = 0;
+    int ercount, cages, hanging, bmons, tele, arrival, you, mons, exits;
+    int x, y;
+    char buf[80];
+    ercount = hanging = cages = bmons = tele = arrival = you = mons = exits =
+        0;
 
-move(20,0);
-addstr("Checking screen legality..."); refresh();
-for( x = 0 ; x < ROWLEN ; x++)
-    for( y = 0 ; y < NOOFROWS ; y++) {
-        move(y+1,x+1); addch('?'); refresh();
-        switch(screen[y][x]) {
-          case '+': cages++; break;
-          case 'S': bmons++; break;
-          case 'T': tele++; break;
-          case 'A': arrival++; break;
-          case '@': you++; break;
-          case 'M': mons++; break;
-          case 'X': exits++; break;
-          case '-':
-          case ' ': if((screen[y-1][x] == 'O')&&(y>0)) hanging++;
-                    if((screen[y+1][x] == '^')&&(y<NOOFROWS)) hanging++;
-                    if((screen[y][x-1] == '>')&&(x>0)) hanging++;
-                    if((screen[y][x+1] == '<')&&(x<ROWLEN)) hanging++;
-                    break;
-          default : break;
+    move(20, 0);
+    addstr("Checking screen legality...");
+    refresh();
+    for (x = 0; x < ROWLEN; x++)
+        for (y = 0; y < NOOFROWS; y++)
+        {
+            move(y + 1, x + 1);
+            addch('?');
+            refresh();
+            switch (screen[y][x])
+            {
+            case '+':
+                cages++;
+                break;
+            case 'S':
+                bmons++;
+                break;
+            case 'T':
+                tele++;
+                break;
+            case 'A':
+                arrival++;
+                break;
+            case '@':
+                you++;
+                break;
+            case 'M':
+                mons++;
+                break;
+            case 'X':
+                exits++;
+                break;
+            case '-':
+            case ' ':
+                if ((screen[y - 1][x] == 'O') && (y > 0))
+                    hanging++;
+                if ((screen[y + 1][x] == '^') && (y < NOOFROWS))
+                    hanging++;
+                if ((screen[y][x - 1] == '>') && (x > 0))
+                    hanging++;
+                if ((screen[y][x + 1] == '<') && (x < ROWLEN))
+                    hanging++;
+                break;
+            default:
+                break;
+            }
+            move(y + 1, x + 1);
+            addch(screen[y][x]);
         }
-        move(y+1,x+1); addch(screen[y][x]);
-    }
-move(20,0); addstr("                         ");
-if(cages != bmons) {
+    move(20, 0);
+    addstr("                         ");
+    if (cages != bmons)
+    {
         ercount++;
-        if( cages < bmons )
-            sprintf(buf,"++++ Warning: %d cage(s), %d baby monster(s).",cages,bmons);
+        if (cages < bmons)
+            sprintf(buf, "++++ Warning: %d cage(s), %d baby monster(s).",
+                    cages, bmons);
         else
-            sprintf(buf,"**** Cage imbalance: %d cage(s), %d baby monster(s).",cages,bmons);
-        if(inform_me(buf,1)) return;
-}
-if(tele > 1) {
+            sprintf(buf,
+                    "**** Cage imbalance: %d cage(s), %d baby monster(s).",
+                    cages, bmons);
+        if (inform_me(buf, 1))
+            return;
+    }
+    if (tele > 1)
+    {
         ercount++;
-        if(inform_me("++++ Warning: Too many teleports",1)) return;
-}
-if(arrival > ((tele>0)?1:0)) {
+        if (inform_me("++++ Warning: Too many teleports", 1))
+            return;
+    }
+    if (arrival > ((tele > 0) ? 1 : 0))
+    {
         ercount++;
-        if(tele == 0) {
-            if(inform_me("**** No arrivals without teleports.",1)) return;
-        } else if(inform_me("**** Too many arrivals.",1)) return;
-}
-if(( arrival == 0 ) && ( tele > 0 )) {
+        if (tele == 0)
+        {
+            if (inform_me("**** No arrivals without teleports.", 1))
+                return;
+        }
+        else if (inform_me("**** Too many arrivals.", 1))
+            return;
+    }
+    if ((arrival == 0) && (tele > 0))
+    {
         ercount++;
-        if(inform_me("**** No arrival for teleport.",1)) return;
-}
-if( you != 1 ) {
+        if (inform_me("**** No arrival for teleport.", 1))
+            return;
+    }
+    if (you != 1)
+    {
         ercount++;
-        if( you == 0 ) {
-            if(inform_me("**** No start position.",1)) return;
-        } else if(inform_me("**** Too many start positions.",1))return;
-}
-if( mons > 1 ) {
+        if (you == 0)
+        {
+            if (inform_me("**** No start position.", 1))
+                return;
+        }
+        else if (inform_me("**** Too many start positions.", 1))
+            return;
+    }
+    if (mons > 1)
+    {
         ercount++;
-        if(inform_me("**** Too many monsters.",1))return;
-}
-if( exits != 1 ) {
+        if (inform_me("**** Too many monsters.", 1))
+            return;
+    }
+    if (exits != 1)
+    {
         ercount++;
-        if( exits == 0 ) {
-            if(inform_me("**** No exit to screen.",1))return;
-        } else if(inform_me("++++ Warning: Too many exits.",1))return;
-}
-if( hanging > 0 ) {
-        sprintf(buf,"++++ Warning: %d hanging boulders/arrows/balloons.",hanging);
-        if(inform_me(buf,1)) return;
-}
-ercount += hanging;
-move(19,0);
-if( ercount == 0 ) inform_me("---- Screen OK.",0);
-else {
-    sprintf(buf,"---- Total errors: %d",ercount);
-    inform_me(buf,0);
-}
-refresh();
+        if (exits == 0)
+        {
+            if (inform_me("**** No exit to screen.", 1))
+                return;
+        }
+        else if (inform_me("++++ Warning: Too many exits.", 1))
+            return;
+    }
+    if (hanging > 0)
+    {
+        sprintf(buf, "++++ Warning: %d hanging boulders/arrows/balloons.",
+                hanging);
+        if (inform_me(buf, 1))
+            return;
+    }
+    ercount += hanging;
+    move(19, 0);
+    if (ercount == 0)
+        inform_me("---- Screen OK.", 0);
+    else
+    {
+        sprintf(buf, "---- Total errors: %d", ercount);
+        inform_me(buf, 0);
+    }
+    refresh();
 }
 
 /**************************************************************
@@ -136,39 +196,48 @@ refresh();
 ***************************************************************/
 void readstring(char *str, int size)
 {
-  int count = 0;
-  char ch;
-  for(;;) {
-    ch = getch();
-    if( ch == '\n' ) {
-        *str = '\0';
-        break;
-    }
-    if(( ch == '\010') || ( ch == '\177' )) {
-        if(count == 0)
+    int count = 0;
+    char ch;
+    for (;;)
+    {
+        ch = getch();
+        if (ch == '\n')
+        {
+            *str = '\0';
+            break;
+        }
+        if ((ch == '\010') || (ch == '\177'))
+        {
+            if (count == 0)
                 continue;
-        str--; count--;
-        addstr("\b \b");
+            str--;
+            count--;
+            addstr("\b \b");
+            refresh();
+            continue;
+        }
+        if (count == size)
+        {
+            printf("\007");
+            continue;
+        }
+        addch(ch);
+        *str = ch;
+        str++;
+        count++;
         refresh();
-        continue;
     }
-    if(count == size) {
-        printf("\007");
-        continue;
-    }
-    addch(ch);
-    *str = ch;
-    str++; count++;
-    refresh();
-  }
 }
 
 void clearbottom()
 {
-move(20,0);
-addstr("                                                                            \n");
-addstr("                                                                            \n");
-addstr("                                                                            ");
+    move(20, 0);
+    addstr
+        ("                                                                            \n");
+    addstr
+        ("                                                                            \n");
+    addstr
+        ("                                                                            ");
 }
 
 /*****************************************
@@ -177,15 +246,17 @@ addstr("                                                                        
 ******************************************/
 void instruct()
 {
-int loop;
-for(loop = 0; inst[loop] ; loop++)
+    int loop;
+    for (loop = 0; inst[loop]; loop++)
     {
-    move(loop,45);
-    addstr(inst[loop]);
+        move(loop, 45);
+        addstr(inst[loop]);
     }
-move(21,0);
-addstr("c: change name, m: change moves, q: save and exit, n/p: play game\n");
-addstr("Press '?' for full editor instructions. Use wanderer keys to move.");
+    move(21, 0);
+    addstr
+        ("c: change name, m: change moves, q: save and exit, n/p: play game\n");
+    addstr
+        ("Press '?' for full editor instructions. Use wanderer keys to move.");
 }
 
 
@@ -194,13 +265,13 @@ addstr("Press '?' for full editor instructions. Use wanderer keys to move.");
 *************************************************/
 void noins()
 {
-int loop;
-for(loop =0; inst[loop] ; loop++)
+    int loop;
+    for (loop = 0; inst[loop]; loop++)
     {
-    move(loop,45);
-    addstr("                              ");
+        move(loop, 45);
+        addstr("                              ");
     }
-clearbottom();
+    clearbottom();
 }
 
 /********************************
@@ -209,32 +280,37 @@ clearbottom();
 *********************************/
 void screen_save(int maxmoves)
 {
-char file[90];
-char *oldname;
-int y;
+    char file[90];
+    char *oldname;
+    int y;
 
-clearbottom();
-move(20,0);
-addstr("Filename to write to? :");
-if(edit_screen)
-    addstr(edit_screen);
-else
-    addstr("./screen");
-move(20,23); refresh();
-addstr("                                   "); move(20,23);
-readstring(file,89);
-move(20,0);
-addstr("                                                                           "); refresh();
-oldname = edit_screen;
-if( file[0] ) edit_screen = file;
-for(y = 0; y<NOOFROWS;y++)        /* make sure screen written */
-    if(screen[y][ROWLEN-1] == ' ') /* correctly...             */
-        screen[y][ROWLEN-1] = '-';
-wscreen(maxmoves);
-for(y = 0; y<NOOFROWS;y++)
-    if(screen[y][ROWLEN-1] == '-')
-        screen[y][ROWLEN-1] = ' ';
-edit_screen = oldname;
+    clearbottom();
+    move(20, 0);
+    addstr("Filename to write to? :");
+    if (edit_screen)
+        addstr(edit_screen);
+    else
+        addstr("./screen");
+    move(20, 23);
+    refresh();
+    addstr("                                   ");
+    move(20, 23);
+    readstring(file, 89);
+    move(20, 0);
+    addstr
+        ("                                                                           ");
+    refresh();
+    oldname = edit_screen;
+    if (file[0])
+        edit_screen = file;
+    for (y = 0; y < NOOFROWS; y++)      /* make sure screen written */
+        if (screen[y][ROWLEN - 1] == ' ')       /* correctly...             */
+            screen[y][ROWLEN - 1] = '-';
+    wscreen(maxmoves);
+    for (y = 0; y < NOOFROWS; y++)
+        if (screen[y][ROWLEN - 1] == '-')
+            screen[y][ROWLEN - 1] = ' ';
+    edit_screen = oldname;
 }
 
 /*********************************************
@@ -246,20 +322,25 @@ void screen_read(int *maxmoves)
     int y;
 
     clearbottom();
-    move(20,0);
+    move(20, 0);
     addstr("Filename to read from? :");
     addstr("Forget it");
-    move(20,24); refresh();
-    addstr("                                   "); move(20,24);
-    readstring(file,89);
-    move(20,0);
-    addstr("                                                                           "); refresh();
-    if( ! file[0] ) return;
+    move(20, 24);
+    refresh();
+    addstr("                                   ");
+    move(20, 24);
+    readstring(file, 89);
+    move(20, 0);
+    addstr
+        ("                                                                           ");
+    refresh();
+    if (!file[0])
+        return;
     edit_screen = file;
-    rscreen(0,maxmoves);
-    for(y = 0; y<NOOFROWS;y++)
-        if(screen[y][ROWLEN-1] == '-')
-            screen[y][ROWLEN-1] = ' ';
+    rscreen(0, maxmoves);
+    for (y = 0; y < NOOFROWS; y++)
+        if (screen[y][ROWLEN - 1] == '-')
+            screen[y][ROWLEN - 1] = ' ';
 }
 
 
@@ -270,18 +351,26 @@ void screen_read(int *maxmoves)
 void edit_save()
 {
     char file[90];
-    int i = 0,fd;
+    int i = 0, fd;
 
     clearbottom();
-    move(20,0);
-    addstr("Filename to save? :"); refresh();
-    readstring(file,89);
-    move(20,0); addstr("                                                                           "); refresh();
-    if(( fd = open(file,O_WRONLY|O_CREAT|O_TRUNC,0644)) == -1 ) {
-        inform_me("File cannot be opened for writing.",0);
-    } else {
-        i = write(fd, edit_memory, (int)(memory_end - edit_memory));
-    if( i < 0 ) inform_me("Write error on file.",0);
+    move(20, 0);
+    addstr("Filename to save? :");
+    refresh();
+    readstring(file, 89);
+    move(20, 0);
+    addstr
+        ("                                                                           ");
+    refresh();
+    if ((fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0644)) == -1)
+    {
+        inform_me("File cannot be opened for writing.", 0);
+    }
+    else
+    {
+        i = write(fd, edit_memory, (int) (memory_end - edit_memory));
+        if (i < 0)
+            inform_me("Write error on file.", 0);
     }
     instruct();
 }
@@ -291,28 +380,38 @@ void edit_save()
 ********************************************/
 void edit_restore()
 {
-char file[90];
-int i = 0,fd;
+    char file[90];
+    int i = 0, fd;
 
-clearbottom();
-move(20,0);
-addstr("Filename to load? :"); refresh();
-readstring(file,89);
-move(20,0); addstr("                                                                           "); refresh();
-move(19,0);
-if(( fd = open(file,O_RDONLY)) == -1 ) {
-    inform_me("File cannot be opened for reading.",0);
-} else {
-    i = read(fd, edit_memory, EMSIZE);
-    if( i < 0 ) inform_me("Read error on file.",0);
-    if( i == 0 ) inform_me("File empty.",0);
-    if( i > 0 ) {
-        sprintf(file,"Read in %d moves.",i);
-        inform_me(file,0);
-        memory_end = edit_memory + i;
+    clearbottom();
+    move(20, 0);
+    addstr("Filename to load? :");
+    refresh();
+    readstring(file, 89);
+    move(20, 0);
+    addstr
+        ("                                                                           ");
+    refresh();
+    move(19, 0);
+    if ((fd = open(file, O_RDONLY)) == -1)
+    {
+        inform_me("File cannot be opened for reading.", 0);
     }
-}
-instruct();
+    else
+    {
+        i = read(fd, edit_memory, EMSIZE);
+        if (i < 0)
+            inform_me("Read error on file.", 0);
+        if (i == 0)
+            inform_me("File empty.", 0);
+        if (i > 0)
+        {
+            sprintf(file, "Read in %d moves.", i);
+            inform_me(file, 0);
+            memory_end = edit_memory + i;
+        }
+    }
+    instruct();
 }
 
 /*************************
@@ -321,42 +420,43 @@ instruct();
 **************************/
 void editscreen(int num, long *score, int *bell, int maxmoves, char keys[10])
 {
-    int  mmbkup,x,y,sx=0,sy=0,quit=0,nx,ny,nosave =0;
-    char (*frow)[ROWLEN+1] = screen,
-         ch;
+    int mmbkup, x, y, sx = 0, sy = 0, quit = 0, nx, ny, nosave = 0;
+    char (*frow)[ROWLEN + 1] = screen, ch;
     char buffer[50];
     char *howdead;
     char *storage;
 
-    if((storage = (char *) malloc(sizeof(screen)))== NULL) {
+    if ((storage = (char *) malloc(sizeof(screen))) == NULL)
+    {
         addstr("OOps... cant malloc a backup screen!\n\n");
         return;
     }
 
-    for(x=0;x<=ROWLEN;x++)
-        for(y=0;y<NOOFROWS;y++)
+    for (x = 0; x <= ROWLEN; x++)
+        for (y = 0; y < NOOFROWS; y++)
         {
-            if(screen[y][x] == '@')
+            if (screen[y][x] == '@')
             {
                 sx = x;
                 sy = y;
             }
-            if(screen[y][x] == '-')
+            if (screen[y][x] == '-')
                 screen[y][x] = ' ';
         };
-    x=sx;
-    y=sy;
-    if(maxmoves != 0)
-        sprintf(buffer,"Moves   : %d        ",maxmoves);
+    x = sx;
+    y = sy;
+    if (maxmoves != 0)
+        sprintf(buffer, "Moves   : %d        ", maxmoves);
     else
-        strcpy(buffer,"Moves   : Unlimited");
-    debug_disp=1;
+        strcpy(buffer, "Moves   : Unlimited");
+    debug_disp = 1;
     map(frow);
-    move(18,0);
+    move(18, 0);
     addstr(buffer);
-    move(19,0);
-    addstr("                                                                          ");
-    move(19,0);
+    move(19, 0);
+    addstr
+        ("                                                                          ");
+    move(19, 0);
     addstr("Name    : ");
     addstr(screen_name);
 
@@ -365,216 +465,235 @@ void editscreen(int num, long *score, int *bell, int maxmoves, char keys[10])
     instruct();
 /* HERE */
 /* Beginning of long while loop */
-while(!quit)
-{
-    move(y+1,x+1);
-    refresh();
-    ch = (char)getchar();
-
-    nx=x;
-    ny=y;
-
-    if(ch == keys[3]||ch == keys[2]||ch == keys[1]||ch == keys[0])
+    while (!quit)
     {
-        if(ch == keys[3])
-           nx++;
-        if(ch == keys[2])
+        move(y + 1, x + 1);
+        refresh();
+        ch = (char) getchar();
+
+        nx = x;
+        ny = y;
+
+        if (ch == keys[3] || ch == keys[2] || ch == keys[1] || ch == keys[0])
+        {
+            if (ch == keys[3])
+                nx++;
+            if (ch == keys[2])
                 nx--;
-        if(ch == keys[1])
-            ny++;
-        if(ch == keys[0])
-            ny--;
-    }
-    else if(ch == 'q')
-    {
-        clearbottom();
-        break;
-    }
-    else if(ch == 'x')
-    {
-        clearbottom();
-        move(20,0);
-        addstr("You will lose any changes made this session - are you sure? (y/n)");
-        refresh();
-        ch = getch();
-        if(ch != 'y')
+            if (ch == keys[1])
+                ny++;
+            if (ch == keys[0])
+                ny--;
+        }
+        else if (ch == 'q')
         {
-            noins();
-            instruct();
-            refresh();
-            }
-        else
-        {
-            nosave = 1;
-            addstr("\n");
-            refresh();
+            clearbottom();
             break;
+        }
+        else if (ch == 'x')
+        {
+            clearbottom();
+            move(20, 0);
+            addstr
+                ("You will lose any changes made this session - are you sure? (y/n)");
+            refresh();
+            ch = getch();
+            if (ch != 'y')
+            {
+                noins();
+                instruct();
+                refresh();
             }
-    }
-    else if(ch == 'm')         /* change to number of moves for the screen */
-    {
-        clearbottom();
-        move(21,0);
-        addstr("How many moves for this screen? :");
-        refresh();echo();
-        if (scanf("%d",&maxmoves) == EOF && errno != 0) {
-            fprintf(stderr, "scanf error\n");
-            exit(EXIT_FAILURE);
+            else
+            {
+                nosave = 1;
+                addstr("\n");
+                refresh();
+                break;
+            }
         }
-        noecho();
-        if(maxmoves < 0 ) maxmoves = 0;
-        if(maxmoves != 0)
-            sprintf(buffer,"Moves   : %d        ",maxmoves);
-        else
-            strcpy(buffer,"Moves   : Unlimited ");
-        instruct();
-        move(18,0);
-        addstr(buffer);
-        refresh();        /* for some reason, this seems to add a '.' to */
-                              /* the map... Ive no idea why yet... */
+        else if (ch == 'm')     /* change to number of moves for the screen */
+        {
+            clearbottom();
+            move(21, 0);
+            addstr("How many moves for this screen? :");
+            refresh();
+            echo();
+            if (scanf("%d", &maxmoves) == EOF && errno != 0)
+            {
+                fprintf(stderr, "scanf error\n");
+                exit(EXIT_FAILURE);
+            }
+            noecho();
+            if (maxmoves < 0)
+                maxmoves = 0;
+            if (maxmoves != 0)
+                sprintf(buffer, "Moves   : %d        ", maxmoves);
+            else
+                strcpy(buffer, "Moves   : Unlimited ");
+            instruct();
+            move(18, 0);
+            addstr(buffer);
+            refresh();          /* for some reason, this seems to add a '.' to */
+            /* the map... Ive no idea why yet... */
         }
-    else if(ch == 'c') {        /* change name */
-        clearbottom();
-        move(21,0);
-        addstr("New name: ");
-        refresh();
-        readstring(screen_name,58);
-        screen_name[61] = '\0';
-        instruct();
-        move(19,0);
-        addstr("                                                                          ");
-        move(19,0);
-        addstr("Name    : ");
-        addstr(screen_name);
-        refresh();
-    }
-    else if(ch == 'p' || ch == 'n')       /* play the game (test) */
-    {
+        else if (ch == 'c')
+        {                       /* change name */
+            clearbottom();
+            move(21, 0);
+            addstr("New name: ");
+            refresh();
+            readstring(screen_name, 58);
+            screen_name[61] = '\0';
+            instruct();
+            move(19, 0);
+            addstr
+                ("                                                                          ");
+            move(19, 0);
+            addstr("Name    : ");
+            addstr(screen_name);
+            refresh();
+        }
+        else if (ch == 'p' || ch == 'n')        /* play the game (test) */
+        {
             noins();
             mmbkup = maxmoves;
-            bcopy(screen,storage,sizeof(screen));
-            if(ch == 'p')
-        {
+            bcopy(screen, storage, sizeof(screen));
+            if (ch == 'p')
+            {
                 debug_disp = 0;
                 clear();
-        }
+            }
             *score = 0;
-            howdead = playscreen(&num,score,bell,maxmoves,keys);
-            move(20,0);
-            if(howdead!=0)
+            howdead = playscreen(&num, score, bell, maxmoves, keys);
+            move(20, 0);
+            if (howdead != 0)
                 addstr(howdead);
             else
                 addstr("DONE!");
             printw("; hit any key to continue\n");
             refresh();
-            ch = (char)getchar();
+            ch = (char) getchar();
             clear();
-            bcopy(storage,screen,sizeof(screen));
+            bcopy(storage, screen, sizeof(screen));
             maxmoves = mmbkup;
             debug_disp = 1;
             map(frow);
-            if(maxmoves != 0)
-                sprintf(buffer,"Moves   : %d        \n",maxmoves);
+            if (maxmoves != 0)
+                sprintf(buffer, "Moves   : %d        \n", maxmoves);
             else
-                strcpy(buffer,"Moves   : Unlimited\n");
-            move(18,0);
+                strcpy(buffer, "Moves   : Unlimited\n");
+            move(18, 0);
             addstr(buffer);
             addstr("Name    : ");
             addstr(screen_name);
             instruct();
-    }
-    else if(ch == 18) {  /* ctrl r -- read memory data */
-        edit_restore();
-    }
-    else if( ch == 23) { /* ctrl w -- write memory data */
-        edit_save();
-    }
-    else if( ch == 7 ) { /* ctrl g -- read screen */
-        screen_read(&maxmoves);
-        map(frow);
-        instruct();
-    }
-    else if( ch == 16 ) { /* ctrl p -- write screen */
-        screen_save(maxmoves);
-        instruct();
-    }
-    else if( ch == 12 ) { /* ctrl l -- redraw screen  */
-        clear();
-        map(frow);
-        if(maxmoves != 0)
-                sprintf(buffer,"Moves   : %d        \n",maxmoves);
-        else
-            strcpy(buffer,"Moves   : Unlimited\n");
-        move(18,0);
-        addstr(buffer);
-        addstr("Name    : ");
-        addstr(screen_name);
-        instruct();
-    }
-    else if( ch == 'L' ) {
-        clearbottom();
-        check_legality();
-        instruct();
-    }
-    else if(ch == '?' ) {
-        helpme(0);
-        if(maxmoves != 0)
-            sprintf(buffer,"Moves   : %d        \n",maxmoves);
-        else
-                strcpy(buffer,"Moves   : Unlimited\n");
-        map(frow);
-    }
-    else if((ch == 127)||(ch == 8)) {  /* delete key */
-        if(--nx < 0)
-            {
-            nx = ROWLEN -1;
-            if(--ny < 0 ) ny = NOOFROWS -1;
         }
-        screen[ny][nx] = ' ';
-        move(ny+1,nx+1);
-        addch(' ');
-    }
-    else
-    {
-        if(ch >= 'a' && ch <= 'z') ch = ch - 'a' + 'A';
-        if(ch == '"') ch = (char)getchar();
-        if( ! (ch < ' ') )
-            {
-            screen[y][x] = ch;
-                   move(y+1,x+1);
-            addch(ch);
-            nx++;
+        else if (ch == 18)
+        {                       /* ctrl r -- read memory data */
+            edit_restore();
         }
+        else if (ch == 23)
+        {                       /* ctrl w -- write memory data */
+            edit_save();
         }
-    if(nx < 0)
+        else if (ch == 7)
+        {                       /* ctrl g -- read screen */
+            screen_read(&maxmoves);
+            map(frow);
+            instruct();
+        }
+        else if (ch == 16)
+        {                       /* ctrl p -- write screen */
+            screen_save(maxmoves);
+            instruct();
+        }
+        else if (ch == 12)
+        {                       /* ctrl l -- redraw screen  */
+            clear();
+            map(frow);
+            if (maxmoves != 0)
+                sprintf(buffer, "Moves   : %d        \n", maxmoves);
+            else
+                strcpy(buffer, "Moves   : Unlimited\n");
+            move(18, 0);
+            addstr(buffer);
+            addstr("Name    : ");
+            addstr(screen_name);
+            instruct();
+        }
+        else if (ch == 'L')
         {
-        nx = ROWLEN-1;
-        ny--;
+            clearbottom();
+            check_legality();
+            instruct();
         }
-    if(nx >= ROWLEN)
+        else if (ch == '?')
         {
-        nx = 0;
-        ny++;
+            helpme(0);
+            if (maxmoves != 0)
+                sprintf(buffer, "Moves   : %d        \n", maxmoves);
+            else
+                strcpy(buffer, "Moves   : Unlimited\n");
+            map(frow);
         }
-    if(ny < 0) ny = NOOFROWS-1;
-    if(ny >= NOOFROWS) ny = 0;
-    move(ny+1,nx+1);
-    x=nx;
-    y=ny;
+        else if ((ch == 127) || (ch == 8))
+        {                       /* delete key */
+            if (--nx < 0)
+            {
+                nx = ROWLEN - 1;
+                if (--ny < 0)
+                    ny = NOOFROWS - 1;
+            }
+            screen[ny][nx] = ' ';
+            move(ny + 1, nx + 1);
+            addch(' ');
+        }
+        else
+        {
+            if (ch >= 'a' && ch <= 'z')
+                ch = ch - 'a' + 'A';
+            if (ch == '"')
+                ch = (char) getchar();
+            if (!(ch < ' '))
+            {
+                screen[y][x] = ch;
+                move(y + 1, x + 1);
+                addch(ch);
+                nx++;
+            }
+        }
+        if (nx < 0)
+        {
+            nx = ROWLEN - 1;
+            ny--;
+        }
+        if (nx >= ROWLEN)
+        {
+            nx = 0;
+            ny++;
+        }
+        if (ny < 0)
+            ny = NOOFROWS - 1;
+        if (ny >= NOOFROWS)
+            ny = 0;
+        move(ny + 1, nx + 1);
+        x = nx;
+        y = ny;
     }
     /* End of while loop */
-    
+
     noins();
-    move(20,0);
+    move(20, 0);
     refresh();
-    
-    if(! nosave)
-        {
-        for(y = 0; y<=NOOFROWS;y++) /* certain editors - eg ded - have a */
-                                    /* habit of truncating trailing spaces*/
-                                            /* so this should stop them! */
-            if(screen[y][ROWLEN-1] == ' ')
-                screen[y][ROWLEN-1] = '-';
+
+    if (!nosave)
+    {
+        for (y = 0; y <= NOOFROWS; y++) /* certain editors - eg ded - have a */
+            /* habit of truncating trailing spaces */
+            /* so this should stop them! */
+            if (screen[y][ROWLEN - 1] == ' ')
+                screen[y][ROWLEN - 1] = '-';
         wscreen(maxmoves);
-        }
+    }
 }

--- a/edit.c
+++ b/edit.c
@@ -106,7 +106,7 @@ void check_legality()
             addch(screen[y][x]);
         }
     move(20, 0);
-    addstr("                         ");
+    printw("%25s", "");
     if (cages != bmons)
     {
         ercount++;
@@ -231,12 +231,9 @@ void readstring(char *str, int size)
 void clearbottom()
 {
     move(20, 0);
-    addstr
-        ("                                                                            \n");
-    addstr
-        ("                                                                            \n");
-    addstr
-        ("                                                                            ");
+    printw("%76s\n", "");
+    printw("%76s\n", "");
+    printw("%76s", "");
 }
 
 /*****************************************
@@ -268,7 +265,7 @@ void noins()
     for (loop = 0; inst[loop]; loop++)
     {
         move(loop, 45);
-        addstr("                              ");
+        printw("%30s", "");
     }
     clearbottom();
 }
@@ -292,12 +289,11 @@ void screen_save(int maxmoves)
         addstr("./screen");
     move(20, 23);
     refresh();
-    addstr("                                   ");
+    printw("%35s", "");
     move(20, 23);
     readstring(file, 89);
     move(20, 0);
-    addstr
-        ("                                                                           ");
+    printw("%75s", "");
     refresh();
     oldname = edit_screen;
     if (file[0])
@@ -326,12 +322,11 @@ void screen_read(int *maxmoves)
     addstr("Forget it");
     move(20, 24);
     refresh();
-    addstr("                                   ");
+    printw("%35s", "");
     move(20, 24);
     readstring(file, 89);
     move(20, 0);
-    addstr
-        ("                                                                           ");
+    printw("%75s", "");
     refresh();
     if (!file[0])
         return;
@@ -358,8 +353,7 @@ void edit_save()
     refresh();
     readstring(file, 89);
     move(20, 0);
-    addstr
-        ("                                                                           ");
+    printw("%75s", "");
     refresh();
     if ((fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0644)) == -1)
     {
@@ -388,8 +382,7 @@ void edit_restore()
     refresh();
     readstring(file, 89);
     move(20, 0);
-    addstr
-        ("                                                                           ");
+    printw("%75s", "");
     refresh();
     move(19, 0);
     if ((fd = open(file, O_RDONLY)) == -1)
@@ -453,8 +446,7 @@ void editscreen(int num, long *score, int *bell, int maxmoves, char keys[10])
     move(18, 0);
     addstr(buffer);
     move(19, 0);
-    addstr
-        ("                                                                          ");
+    printw("%74s", "");
     move(19, 0);
     addstr("Name    : ");
     addstr(screen_name);
@@ -546,8 +538,7 @@ void editscreen(int num, long *score, int *bell, int maxmoves, char keys[10])
             screen_name[61] = '\0';
             instruct();
             move(19, 0);
-            addstr
-                ("                                                                          ");
+            printw("%74s", "");
             move(19, 0);
             addstr("Name    : ");
             addstr(screen_name);

--- a/edit.c
+++ b/edit.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <unistd.h>
 
 extern int debug_disp;
@@ -558,7 +557,7 @@ void editscreen(int num, long *score, int *bell, int maxmoves, char keys[10])
         {
             noins();
             mmbkup = maxmoves;
-            bcopy(screen, storage, sizeof(screen));
+            memcpy(storage, screen, sizeof(screen));
             if (ch == 'p')
             {
                 debug_disp = 0;
@@ -575,7 +574,7 @@ void editscreen(int num, long *score, int *bell, int maxmoves, char keys[10])
             refresh();
             ch = (char) getchar();
             clear();
-            bcopy(storage, screen, sizeof(screen));
+            memcpy(screen, storage, sizeof(screen));
             maxmoves = mmbkup;
             debug_disp = 1;
             map(frow);

--- a/encrypt.c
+++ b/encrypt.c
@@ -13,55 +13,59 @@
 
 void crypt_file(char *name)
 {
-char buffer[1024];
-int fd,length,loop;
+    char buffer[1024];
+    int fd, length, loop;
 
-if((fd = open(name,O_RDONLY)) == -1) {
+    if ((fd = open(name, O_RDONLY)) == -1)
+    {
 #ifndef __CONVERT
         endwin();
 #endif
-        sprintf(buffer,"Wanderer: cannot open %s",name);
+        sprintf(buffer, "Wanderer: cannot open %s", name);
         perror(buffer);
         exit(1);
-}
-if((length = read(fd,buffer,1024)) < 1) {
+    }
+    if ((length = read(fd, buffer, 1024)) < 1)
+    {
 #ifndef __CONVERT
         endwin();
 #endif
-        sprintf(buffer,"Wanderer: read error on %s",name);
+        sprintf(buffer, "Wanderer: read error on %s", name);
         perror(buffer);
         exit(1);
-}
-close(fd);
+    }
+    close(fd);
 
 /* Right, got it in here, now to encrypt the stuff */
 
 #ifndef __CONVERT
-addstr("Running crypt routine....\n");
-refresh();
+    addstr("Running crypt routine....\n");
+    refresh();
 #endif
 
-srand(BLURFL);
-for(loop=0;loop<length;loop++)
-        buffer[loop]^=rand();
+    srand(BLURFL);
+    for (loop = 0; loop < length; loop++)
+        buffer[loop] ^= rand();
 
-if((fd = open(name,O_WRONLY|O_TRUNC))== -1) {
+    if ((fd = open(name, O_WRONLY | O_TRUNC)) == -1)
+    {
 #ifndef __CONVERT
         endwin();
 #endif
-        sprintf(buffer,"Wanderer: cannot write to %s",name);
+        sprintf(buffer, "Wanderer: cannot write to %s", name);
         perror(buffer);
         exit(1);
-}
-if(write(fd,buffer,length)!=length) {
+    }
+    if (write(fd, buffer, length) != length)
+    {
 #ifndef __CONVERT
         endwin();
 #endif
-        sprintf(buffer,"Wanderer: write error on %s",name);
+        sprintf(buffer, "Wanderer: write error on %s", name);
         perror(buffer);
         exit(1);
-}
-close(fd);
+    }
+    close(fd);
 
 /* ok, file now contains encrypted/decrypted game. */
 /* lets go back home... */

--- a/fall.c
+++ b/fall.c
@@ -8,9 +8,9 @@
 #include <string.h>
 
 extern int debug_disp;
-extern char screen[NOOFROWS][ROWLEN+1];
+extern char screen[NOOFROWS][ROWLEN + 1];
 
-int moving = 0; /* so that bombs explode only if something *hits* them */
+int moving = 0;                 /* so that bombs explode only if something *hits* them */
 
 /***************************************************** 
 *                 Function check                     *
@@ -19,15 +19,16 @@ int moving = 0; /* so that bombs explode only if something *hits* them */
 *  vector dx,dy. All the others are constant and should really have   *
 *  been global...                                                     */
 
-int check(int *mx, int *my, int x, int y, int dx, int dy, int sx, int sy, char howdead[25])
+int check(int *mx, int *my, int x, int y, int dx, int dy, int sx, int sy,
+          char howdead[25])
 {
-    int ret=0;
-    ret+=fall(mx,my,x,y,sx,sy,howdead);
-    ret+=fall(mx,my,x-dx,y-dy,sx,sy,howdead);
-    ret+=fall(mx,my,x-dy,y-dx,sx,sy,howdead);
-    ret+=fall(mx,my,x+dy,y+dx,sx,sy,howdead);
-    ret+=fall(mx,my,x-dx-dy,y-dy-dx,sx,sy,howdead);
-    ret+=fall(mx,my,x-dx+dy,y-dy+dx,sx,sy,howdead);
+    int ret = 0;
+    ret += fall(mx, my, x, y, sx, sy, howdead);
+    ret += fall(mx, my, x - dx, y - dy, sx, sy, howdead);
+    ret += fall(mx, my, x - dy, y - dx, sx, sy, howdead);
+    ret += fall(mx, my, x + dy, y + dx, sx, sy, howdead);
+    ret += fall(mx, my, x - dx - dy, y - dy - dx, sx, sy, howdead);
+    ret += fall(mx, my, x - dx + dy, y - dy + dx, sx, sy, howdead);
     return ret;
 }
 
@@ -39,313 +40,348 @@ int check(int *mx, int *my, int x, int y, int dx, int dy, int sx, int sy, char h
 ***********************************/
 int fall(int *mx, int *my, int x, int y, int sx, int sy, char howdead[25])
 {
-int nx = x,nxu = x,nyl = y,nyr = y,ny = y,retval = 0;
-if ((y>(NOOFROWS-1))||(y<0)||(x<0)||(x>(ROWLEN-1)))
-    return(0);
-if(screen[y][x] == '~') {
-   if( screen[y-1][x] == ' ' ) fall(mx,my,x,y-1,sx,sy,howdead);
-   if( screen[y+1][x] == ' ' ) fall(mx,my,x,y+1,sx,sy,howdead);
-   if( screen[y][x-1] == ' ' ) fall(mx,my,x-1,y,sx,sy,howdead);
-   if( screen[y][x+1] == ' ' ) fall(mx,my,x+1,y,sx,sy,howdead);
-}
-if((screen[y][x] != 'O') && (screen[y][x] != ' ') && (screen[y][x] != 'M') &&
-   (screen[y][x] !='\\') && (screen[y][x] != '/') && (screen[y][x] != '@') &&
-   (screen[y][x] != '^') && (screen[y][x] != 'B'))
-    return(0);
-if((screen[y][x] == 'B') && (moving == 0 )) return 0;
-if(screen[y][x] == 'O')
+    int nx = x, nxu = x, nyl = y, nyr = y, ny = y, retval = 0;
+    if ((y > (NOOFROWS - 1)) || (y < 0) || (x < 0) || (x > (ROWLEN - 1)))
+        return (0);
+    if (screen[y][x] == '~')
     {
-    if((screen[y][x-1] == ' ') && (screen[y-1][x-1] == ' '))
-        nx--;
-    else
-        {
-        if((screen[y][x+1] == ' ') && (screen[y-1][x+1] == ' '))
-            nx++;
+        if (screen[y - 1][x] == ' ')
+            fall(mx, my, x, y - 1, sx, sy, howdead);
+        if (screen[y + 1][x] == ' ')
+            fall(mx, my, x, y + 1, sx, sy, howdead);
+        if (screen[y][x - 1] == ' ')
+            fall(mx, my, x - 1, y, sx, sy, howdead);
+        if (screen[y][x + 1] == ' ')
+            fall(mx, my, x + 1, y, sx, sy, howdead);
+    }
+    if ((screen[y][x] != 'O') && (screen[y][x] != ' ') && (screen[y][x] != 'M')
+        && (screen[y][x] != '\\') && (screen[y][x] != '/')
+        && (screen[y][x] != '@') && (screen[y][x] != '^')
+        && (screen[y][x] != 'B'))
+        return (0);
+    if ((screen[y][x] == 'B') && (moving == 0))
+        return 0;
+    if (screen[y][x] == 'O')
+    {
+        if ((screen[y][x - 1] == ' ') && (screen[y - 1][x - 1] == ' '))
+            nx--;
         else
+        {
+            if ((screen[y][x + 1] == ' ') && (screen[y - 1][x + 1] == ' '))
+                nx++;
+            else
+                nx = -1;
+        }
+        if ((screen[y][x - 1] == ' ') && (screen[y + 1][x - 1] == ' '))
+            nxu--;
+        else
+        {
+            if ((screen[y][x + 1] == ' ') && (screen[y + 1][x + 1] == ' '))
+                nxu++;
+            else
+                nxu = -1;
+        }
+        if ((screen[y - 1][x] == ' ') && (screen[y - 1][x + 1] == ' '))
+            nyr--;
+        else
+        {
+            if ((screen[y + 1][x] == ' ') && (screen[y + 1][x + 1] == ' '))
+                nyr++;
+            else
+                nyr = -1;
+        }
+        if ((screen[y - 1][x] == ' ') && (screen[y - 1][x - 1] == ' '))
+            nyl--;
+        else
+        {
+            if ((screen[y + 1][x] == ' ') && (screen[y + 1][x - 1] == ' '))
+                nyl++;
+            else
+                nyl = -1;
+        }
+    }
+    if (screen[y][x] == '\\')
+    {
+        if (screen[y - 1][++nx] != ' ')
             nx = -1;
-        }
-    if((screen[y][x-1] == ' ') && (screen[y+1][x-1] == ' '))
-        nxu--;
-    else
-        {
-        if((screen[y][x+1] == ' ') && (screen[y+1][x+1] == ' '))
-            nxu++;
-        else
+        if (screen[y + 1][--nxu] != ' ')
             nxu = -1;
-        }
-    if((screen[y-1][x] == ' ') && (screen[y-1][x+1] == ' '))
-        nyr--;
-    else
-        {
-        if((screen[y+1][x] == ' ') && (screen[y+1][x+1] == ' '))
-            nyr++;
-        else
+        if (screen[--nyr][x + 1] != ' ')
             nyr = -1;
-        }
-    if((screen[y-1][x] == ' ') && (screen[y-1][x-1] == ' '))
-        nyl--;
-    else
-        {
-        if((screen[y+1][x] == ' ') && (screen[y+1][x-1] == ' '))
-            nyl++;
-        else
+        if (screen[++nyl][x - 1] != ' ')
             nyl = -1;
-        }
     }
-if(screen[y][x] == '\\')
+    if (screen[y][x] == '/')
     {
-    if(screen[y-1][++nx] != ' ')
+        if (screen[y - 1][--nx] != ' ')
+            nx = -1;
+        if (screen[y + 1][++nxu] != ' ')
+            nxu = -1;
+        if (screen[++nyr][x + 1] != ' ')
+            nyr = -1;
+        if (screen[--nyl][x - 1] != ' ')
+            nyl = -1;
+    }
+    if ((screen[y][nx] != ' ') && (screen[y][nx] != 'M')
+        && (screen[y][nx] != 'B'))
         nx = -1;
-    if(screen[y+1][--nxu] != ' ')
-        nxu = -1;
-    if(screen[--nyr][x+1] != ' ')
-        nyr = -1;
-    if(screen[++nyl][x-1] != ' ')
-        nyl = -1;
-    }
-if(screen[y][x] == '/')
+    if ((screen[y - 1][x] == 'O') && (nx >= 0) && (y > 0))      /* boulder falls ? */
     {
-    if(screen[y-1][--nx] != ' ')
-        nx = -1;
-    if(screen[y+1][++nxu] != ' ')
-        nxu = -1;
-    if(screen[++nyr][x+1] != ' ')
-        nyr = -1;
-    if(screen[--nyl][x-1] != ' ')
-        nyl = -1;
-    }
-if((screen[y][nx] != ' ') && (screen[y][nx] != 'M') && (screen[y][nx] != 'B'))
-    nx = -1;
-if((screen[y-1][x] == 'O') && (nx >= 0) && (y > 0)) /* boulder falls ? */
-    {
-    moving = 1;
-    screen[y-1][x] = ' ';
-    if(screen[y][nx] == '@')
+        moving = 1;
+        screen[y - 1][x] = ' ';
+        if (screen[y][nx] == '@')
         {
-            strcpy(howdead,"a falling boulder");
-            retval=1;
-            }
-    if(screen[y][nx] == 'M')
-        {
-            *mx = *my = -2;
-        screen[y][nx] = ' ';
-            }
-    if(screen[y][nx] == 'B')
-        {
-        retval = bang(nx,y,mx,my,sx,sy,howdead);
-        return retval;
-        }
-    screen[y][nx] = 'O';
-    if(!debug_disp)
-        {
-        if((y<(sy+5)) && (y>(sy-3)) && (x>(sx-6)) && (x<(sx+6)))
-            draw_symbol((x-sx+5)*3,(y-sy+2)*2,' ');
-        if((y<(sy+4)) && (y>(sy-4)) && (nx>(sx-6)) && (nx<(sx+6)))
-            draw_symbol((nx-sx+5)*3,(y-sy+3)*2,'O');
-        }
-    else
-        {
-        move(y,x+1);
-        addch(' ');;
-        move(y+1,nx+1);
-        addch('O');
-    }
-    refresh();
-    retval+=fall(mx,my,nx ,y+1,sx,sy,howdead);
-    moving = 0;
-    retval+=check(mx,my,x,y-1,0,1,sx,sy,howdead);
-    if(screen[y+1][nx] == '@')
-        {
-            strcpy(howdead,"a falling boulder");
-            return(1);
-            }
-    if(screen[y+1][nx] == 'M')
-        {
-            *mx = *my = -2;
-        screen[y+1][nx] = ' ';
-            }
-    }
-if((screen[nyr][x] != '^')&&(screen[nyr][x] != ' ')&&(screen[nyr][x] != 'M')
-   &&(screen[nyr][x] != 'B'))
-    nyr = -1;
-if((screen[y][x+1] == '<')&&(nyr>=0)&&(x+1<ROWLEN)) /* arrow moves ( < ) ? */
-    {
-    moving = 1;
-    screen[y][x+1] = ' ';
-    if(screen[nyr][x] == '@')
-        {
-            strcpy(howdead,"a speeding arrow");
+            strcpy(howdead, "a falling boulder");
             retval = 1;
-            }
-    if(screen[nyr][x] == 'M')
+        }
+        if (screen[y][nx] == 'M')
         {
             *mx = *my = -2;
-        screen[nyr][x] = ' ';
-            }
-    if(screen[nyr][x] == 'B')
-        {
-        retval = bang(x,nyr,mx,my,sx,sy,howdead);
-        return retval;
+            screen[y][nx] = ' ';
         }
-    screen[nyr][x] = '<';
-    if(!debug_disp)
+        if (screen[y][nx] == 'B')
         {
-        if((y<(sy+4)) && (y>(sy-4)) && (x<(sx+5)) && (x>(sx-7)))
-            draw_symbol((x-sx+6)*3,(y-sy+3)*2,' ');
-        if((nyr<(sy+4)) && (nyr>(sy-4)) && (x<(sx+6)) && (x>(sx-6)))
-            draw_symbol((x-sx+5)*3,(nyr-sy+3)*2,'<');
+            retval = bang(nx, y, mx, my, sx, sy, howdead);
+            return retval;
         }
-    else
+        screen[y][nx] = 'O';
+        if (!debug_disp)
         {
-        move(y+1,x+2);
-        addch(' ');
-        move(nyr+1,x+1);
-        addch('<');
+            if ((y < (sy + 5)) && (y > (sy - 3)) && (x > (sx - 6))
+                && (x < (sx + 6)))
+                draw_symbol((x - sx + 5) * 3, (y - sy + 2) * 2, ' ');
+            if ((y < (sy + 4)) && (y > (sy - 4)) && (nx > (sx - 6))
+                && (nx < (sx + 6)))
+                draw_symbol((nx - sx + 5) * 3, (y - sy + 3) * 2, 'O');
         }
-    refresh();
-    retval+=fall(mx,my,x-1,nyr,sx,sy,howdead);
-    moving = 0;
-    retval+=check(mx,my,x+1,y,-1,0,sx,sy,howdead);
-    if(screen[nyr][x-1] == '@')
+        else
         {
-            strcpy(howdead,"a speeding arrow");
-            return(1);
-            }
-    if(screen[nyr][x-1] == 'M')
-        {
-            *mx = *my = -2;
-        screen[nyr][x-1] = ' ';
-            }
-    }
-if((screen[nyl][x] != ' ')&&(screen[nyl][x] != '^')&&(screen[nyl][x] != 'M')
-    &&( screen[nyl][x] != 'B'))
-    nyl = -1;
-if((screen[y][x-1] == '>')&&(nyl>=0)&&(x>0))       /* arrow moves ( > ) ? */
-    {
-    moving = 1;
-    screen[y][x-1] = ' ';
-    if(screen[nyl][x] == '@')
-        {
-            strcpy(howdead,"a speeding arrow");
-            retval = 1;
-            }
-    if(screen[nyl][x] == 'M')
-        {
-            *mx = *my = -2;
-        screen[nyl][x] = ' ';
-            }
-    if(screen[nyr][x] == 'B')
-        {
-        retval = bang(x,nyr,mx,my,sx,sy,howdead);
-        return retval;
-        }
-    screen[nyl][x] = '>';
-    if(!debug_disp)
-        {
-        if((y<(sy+4)) && (y>(sy-4)) && (x<(sx+7)) && (x>(sx-5)))
-            draw_symbol((x-sx+4)*3,(y-sy+3)*2,' ');
-        if((nyl<(sy+4)) && (nyl>(sy-4)) && (x<(sx+6)) && (x>(sx-6)))
-            draw_symbol((x-sx+5)*3,(nyl-sy+3)*2,'>');
-        }
-    else
-        {
-        move(y+1,x);
-        addch(' ');
-        move(nyl+1,x+1);
-        addch('>');
-        }
-    refresh();
-    retval+=fall(mx,my,x+1,nyl,sx,sy,howdead);
-    moving = 0;
-    retval+=check(mx,my,x-1,y,1,0,sx,sy,howdead);
-    if(screen[nyl][x+1] == '@')
-        {
-            strcpy(howdead,"a speeding arrow");
-            return(1);
-            }
-    if(screen[nyl][x+1] == 'M')
-        {
-            *mx = *my = -2;
-        screen[nyl][x+1] = ' ';
-            }
-    }
-
-if(screen[y][nxu] != ' ')
-    nxu = -1;
-
-if((screen[y+1][x] == '^') && (nxu >= 0) && (y < NOOFROWS) &&
-   (screen[y][x] != '^')&&(screen[y][x] != 'B')) /* balloon rises? */
-    {
-    screen[y+1][x] = ' ';
-    screen[y][nxu] = '^';
-    if(!debug_disp)
-        {
-        if((y<(sy+3)) && (y>(sy-5)) && (x>(sx-6)) && (x<(sx+6)))
-            draw_symbol((x-sx+5)*3,(y-sy+4)*2,' ');
-        if((y<(sy+4)) && (y>(sy-4)) && (nxu>(sx-6)) && (nxu<(sx+6)))
-            draw_symbol((nxu-sx+5)*3,(y-sy+3)*2,'^');
-        }
-    else
-        {
-        move(y+2,x+1);
-        addch(' ');
-        move(y+1,nxu+1);
-        addch('^');
-    }
-    refresh();
-    retval+=fall(mx,my,nxu ,y-1,sx,sy,howdead);
-    retval+=check(mx,my,x,y+1,0,-1,sx,sy,howdead);
-    }
-
-nx = x; ny = y;
-
-if(screen[y][x] == ' ') {     /* thingy moves? */
-    if((y>1)&&(screen[y-1][x]=='~')&&(screen[y-2][x]=='O'))
-        /* boulder pushes */
-        ny--;
-    else {
-    if((x>1)&&(screen[y][x-1]=='~')&&(screen[y][x-2]=='>'))
-        /* arrow pushes */
-        nx--;
-    else {
-    if((x<(ROWLEN-1))&&(screen[y][x+1]=='~')&&(screen[y][x+2]=='<'))
-        /* arrow pushes */
-        nx++;
-    else {
-    if((y<(NOOFROWS-1))&&(screen[y+1][x]=='~')&&(screen[y+2][x]=='^'))
-        /* balloon pushes */
-        ny++;
-    }}}
-
-    if(( x != nx )||( y != ny )) {
-        screen[y][x] = '~';
-        screen[ny][nx] = screen[2*ny-y][2*nx-x];
-        screen[2*ny-y][2*nx-x] = ' ';
-           if(!debug_disp) {
-            if(((2*ny-y)<(sy+4)) && ((2*ny-y)>(sy-4))
-                && ((2*nx-x)>(sx-6)) && ((2*nx-x)<(sx+6)))
-                    draw_symbol((2*nx-x-sx+5)*3,(2*ny-y-sy+3)*2,' ');
-            if((y<(sy+4)) && (y>(sy-4)) && (x>(sx-6)) && (x<(sx+6)))
-                    draw_symbol((x-sx+5)*3,(y-sy+3)*2,'~');
-            if((ny<(sy+4)) && (ny>(sy-4)) && (nx>(sx-6)) && (nx<(sx+6)))
-                    draw_symbol((nx-sx+5)*3,(ny-sy+3)*2,screen[ny][nx]);
-        } else {
-            move(ny*2-y+1,nx*2-x+1);
-            addch(' ');
-            move(ny+1,nx+1);
-            addch(screen[ny][nx]);
-            move(y+1,x+1);
-            addch('~');
+            move(y, x + 1);
+            addch(' ');;
+            move(y + 1, nx + 1);
+            addch('O');
         }
         refresh();
-        retval+=fall(mx,my,2*x-nx,2*y-ny,sx,sy,howdead);
-        retval+=check(mx,my,2*nx-x,2*ny-y,nx-x,ny-y,sx,sy,howdead);
+        retval += fall(mx, my, nx, y + 1, sx, sy, howdead);
+        moving = 0;
+        retval += check(mx, my, x, y - 1, 0, 1, sx, sy, howdead);
+        if (screen[y + 1][nx] == '@')
+        {
+            strcpy(howdead, "a falling boulder");
+            return (1);
+        }
+        if (screen[y + 1][nx] == 'M')
+        {
+            *mx = *my = -2;
+            screen[y + 1][nx] = ' ';
+        }
     }
-}
+    if ((screen[nyr][x] != '^') && (screen[nyr][x] != ' ')
+        && (screen[nyr][x] != 'M') && (screen[nyr][x] != 'B'))
+        nyr = -1;
+    if ((screen[y][x + 1] == '<') && (nyr >= 0) && (x + 1 < ROWLEN))    /* arrow moves ( < ) ? */
+    {
+        moving = 1;
+        screen[y][x + 1] = ' ';
+        if (screen[nyr][x] == '@')
+        {
+            strcpy(howdead, "a speeding arrow");
+            retval = 1;
+        }
+        if (screen[nyr][x] == 'M')
+        {
+            *mx = *my = -2;
+            screen[nyr][x] = ' ';
+        }
+        if (screen[nyr][x] == 'B')
+        {
+            retval = bang(x, nyr, mx, my, sx, sy, howdead);
+            return retval;
+        }
+        screen[nyr][x] = '<';
+        if (!debug_disp)
+        {
+            if ((y < (sy + 4)) && (y > (sy - 4)) && (x < (sx + 5))
+                && (x > (sx - 7)))
+                draw_symbol((x - sx + 6) * 3, (y - sy + 3) * 2, ' ');
+            if ((nyr < (sy + 4)) && (nyr > (sy - 4)) && (x < (sx + 6))
+                && (x > (sx - 6)))
+                draw_symbol((x - sx + 5) * 3, (nyr - sy + 3) * 2, '<');
+        }
+        else
+        {
+            move(y + 1, x + 2);
+            addch(' ');
+            move(nyr + 1, x + 1);
+            addch('<');
+        }
+        refresh();
+        retval += fall(mx, my, x - 1, nyr, sx, sy, howdead);
+        moving = 0;
+        retval += check(mx, my, x + 1, y, -1, 0, sx, sy, howdead);
+        if (screen[nyr][x - 1] == '@')
+        {
+            strcpy(howdead, "a speeding arrow");
+            return (1);
+        }
+        if (screen[nyr][x - 1] == 'M')
+        {
+            *mx = *my = -2;
+            screen[nyr][x - 1] = ' ';
+        }
+    }
+    if ((screen[nyl][x] != ' ') && (screen[nyl][x] != '^')
+        && (screen[nyl][x] != 'M') && (screen[nyl][x] != 'B'))
+        nyl = -1;
+    if ((screen[y][x - 1] == '>') && (nyl >= 0) && (x > 0))     /* arrow moves ( > ) ? */
+    {
+        moving = 1;
+        screen[y][x - 1] = ' ';
+        if (screen[nyl][x] == '@')
+        {
+            strcpy(howdead, "a speeding arrow");
+            retval = 1;
+        }
+        if (screen[nyl][x] == 'M')
+        {
+            *mx = *my = -2;
+            screen[nyl][x] = ' ';
+        }
+        if (screen[nyr][x] == 'B')
+        {
+            retval = bang(x, nyr, mx, my, sx, sy, howdead);
+            return retval;
+        }
+        screen[nyl][x] = '>';
+        if (!debug_disp)
+        {
+            if ((y < (sy + 4)) && (y > (sy - 4)) && (x < (sx + 7))
+                && (x > (sx - 5)))
+                draw_symbol((x - sx + 4) * 3, (y - sy + 3) * 2, ' ');
+            if ((nyl < (sy + 4)) && (nyl > (sy - 4)) && (x < (sx + 6))
+                && (x > (sx - 6)))
+                draw_symbol((x - sx + 5) * 3, (nyl - sy + 3) * 2, '>');
+        }
+        else
+        {
+            move(y + 1, x);
+            addch(' ');
+            move(nyl + 1, x + 1);
+            addch('>');
+        }
+        refresh();
+        retval += fall(mx, my, x + 1, nyl, sx, sy, howdead);
+        moving = 0;
+        retval += check(mx, my, x - 1, y, 1, 0, sx, sy, howdead);
+        if (screen[nyl][x + 1] == '@')
+        {
+            strcpy(howdead, "a speeding arrow");
+            return (1);
+        }
+        if (screen[nyl][x + 1] == 'M')
+        {
+            *mx = *my = -2;
+            screen[nyl][x + 1] = ' ';
+        }
+    }
 
-if(retval>0)
-    return(1);
-return(0);
+    if (screen[y][nxu] != ' ')
+        nxu = -1;
+
+    if ((screen[y + 1][x] == '^') && (nxu >= 0) && (y < NOOFROWS) && (screen[y][x] != '^') && (screen[y][x] != 'B'))    /* balloon rises? */
+    {
+        screen[y + 1][x] = ' ';
+        screen[y][nxu] = '^';
+        if (!debug_disp)
+        {
+            if ((y < (sy + 3)) && (y > (sy - 5)) && (x > (sx - 6))
+                && (x < (sx + 6)))
+                draw_symbol((x - sx + 5) * 3, (y - sy + 4) * 2, ' ');
+            if ((y < (sy + 4)) && (y > (sy - 4)) && (nxu > (sx - 6))
+                && (nxu < (sx + 6)))
+                draw_symbol((nxu - sx + 5) * 3, (y - sy + 3) * 2, '^');
+        }
+        else
+        {
+            move(y + 2, x + 1);
+            addch(' ');
+            move(y + 1, nxu + 1);
+            addch('^');
+        }
+        refresh();
+        retval += fall(mx, my, nxu, y - 1, sx, sy, howdead);
+        retval += check(mx, my, x, y + 1, 0, -1, sx, sy, howdead);
+    }
+
+    nx = x;
+    ny = y;
+
+    if (screen[y][x] == ' ')
+    {                           /* thingy moves? */
+        if ((y > 1) && (screen[y - 1][x] == '~') && (screen[y - 2][x] == 'O'))
+            /* boulder pushes */
+            ny--;
+        else
+        {
+            if ((x > 1) && (screen[y][x - 1] == '~')
+                && (screen[y][x - 2] == '>'))
+                /* arrow pushes */
+                nx--;
+            else
+            {
+                if ((x < (ROWLEN - 1)) && (screen[y][x + 1] == '~')
+                    && (screen[y][x + 2] == '<'))
+                    /* arrow pushes */
+                    nx++;
+                else
+                {
+                    if ((y < (NOOFROWS - 1)) && (screen[y + 1][x] == '~')
+                        && (screen[y + 2][x] == '^'))
+                        /* balloon pushes */
+                        ny++;
+                }
+            }
+        }
+
+        if ((x != nx) || (y != ny))
+        {
+            screen[y][x] = '~';
+            screen[ny][nx] = screen[2 * ny - y][2 * nx - x];
+            screen[2 * ny - y][2 * nx - x] = ' ';
+            if (!debug_disp)
+            {
+                if (((2 * ny - y) < (sy + 4)) && ((2 * ny - y) > (sy - 4))
+                    && ((2 * nx - x) > (sx - 6)) && ((2 * nx - x) < (sx + 6)))
+                    draw_symbol((2 * nx - x - sx + 5) * 3,
+                                (2 * ny - y - sy + 3) * 2, ' ');
+                if ((y < (sy + 4)) && (y > (sy - 4)) && (x > (sx - 6))
+                    && (x < (sx + 6)))
+                    draw_symbol((x - sx + 5) * 3, (y - sy + 3) * 2, '~');
+                if ((ny < (sy + 4)) && (ny > (sy - 4)) && (nx > (sx - 6))
+                    && (nx < (sx + 6)))
+                    draw_symbol((nx - sx + 5) * 3, (ny - sy + 3) * 2,
+                                screen[ny][nx]);
+            }
+            else
+            {
+                move(ny * 2 - y + 1, nx * 2 - x + 1);
+                addch(' ');
+                move(ny + 1, nx + 1);
+                addch(screen[ny][nx]);
+                move(y + 1, x + 1);
+                addch('~');
+            }
+            refresh();
+            retval += fall(mx, my, 2 * x - nx, 2 * y - ny, sx, sy, howdead);
+            retval +=
+                check(mx, my, 2 * nx - x, 2 * ny - y, nx - x, ny - y, sx, sy,
+                      howdead);
+        }
+    }
+
+    if (retval > 0)
+        return (1);
+    return (0);
 }
 
 /**********************************************
@@ -354,58 +390,77 @@ return(0);
 int bang(int x, int y, int *mx, int *my, int sx, int sy, char *howdead) /* explosion centre x,y */
 {
     int retval = 0;
-    int ba,bb;  /* abbrevs for 'bang index a' and 'bang index b' :-) */
+    int ba, bb;                 /* abbrevs for 'bang index a' and 'bang index b' :-) */
     int gottim = 0;
     screen[y][x] = ' ';
 /* fill with bangs */
-    for(ba = -1; ba < 2; ba++ )
-        for(bb = -1; bb < 2; bb++ ) {
-            if(screen[y+ba][x+bb] == '#') continue; /* rock indestructable */
-            if(screen[y+ba][x+bb] == '@') gottim = 1;
-            if(screen[y+ba][x+bb] == 'M') *mx = *my = -2; /* kill monster */
-            if(screen[y+ba][x+bb] == 'B')
-                gottim += bang(x+bb,y+ba,mx,my,sx,sy,howdead);
-            screen[y+ba][x+bb] = ' ';
-               if(!debug_disp) {
-                if(((y+ba)<(sy+4)) && ((y+ba)>(sy-4)) && ((x+bb)>(sx-6))
-                && ((x+bb)<(sx+6)) && (y+ba >= 0 ) && (x +bb >= 0) &&
-                ((x+bb)<ROWLEN) && ((y+ba)<NOOFROWS) )
-                        draw_symbol((x+bb-sx+5)*3,(y+ba-sy+3)*2,'%');
-            } else {
-                if( ((x+bb)>-1)     && ((y+ba)>-1) &&
-                ((x+bb)<ROWLEN) && ((y+ba)<NOOFROWS) ) {
-                    move(y+ba+1,x+bb+1);
+    for (ba = -1; ba < 2; ba++)
+        for (bb = -1; bb < 2; bb++)
+        {
+            if (screen[y + ba][x + bb] == '#')
+                continue;       /* rock indestructable */
+            if (screen[y + ba][x + bb] == '@')
+                gottim = 1;
+            if (screen[y + ba][x + bb] == 'M')
+                *mx = *my = -2; /* kill monster */
+            if (screen[y + ba][x + bb] == 'B')
+                gottim += bang(x + bb, y + ba, mx, my, sx, sy, howdead);
+            screen[y + ba][x + bb] = ' ';
+            if (!debug_disp)
+            {
+                if (((y + ba) < (sy + 4)) && ((y + ba) > (sy - 4))
+                    && ((x + bb) > (sx - 6)) && ((x + bb) < (sx + 6))
+                    && (y + ba >= 0) && (x + bb >= 0) && ((x + bb) < ROWLEN)
+                    && ((y + ba) < NOOFROWS))
+                    draw_symbol((x + bb - sx + 5) * 3, (y + ba - sy + 3) * 2,
+                                '%');
+            }
+            else
+            {
+                if (((x + bb) > -1) && ((y + ba) > -1) && ((x + bb) < ROWLEN)
+                    && ((y + ba) < NOOFROWS))
+                {
+                    move(y + ba + 1, x + bb + 1);
                     addch('%');
                 }
             }
         }
     refresh();
-    if(gottim) {
-        strcpy(howdead,"an exploding bomb");
+    if (gottim)
+    {
+        strcpy(howdead, "an exploding bomb");
         return 1;
     }
     /* erase it all */
-    for(ba = -1; ba < 2; ba++ )
-        for(bb = -1; bb < 2; bb++ ) {
-            if(screen[y+ba][x+bb] == '#') continue;
-               if(!debug_disp) {
-                if(((y+ba)<(sy+4)) && ((y+ba)>(sy-4)) && ((x+bb)>(sx-6))
-                && ((x+bb)<(sx+6)) && (y+ba > -1) && (x+bb > -1) &&
-                ((x+bb)<ROWLEN) && ((y+ba)<NOOFROWS) )
-                        draw_symbol((x+bb-sx+5)*3,(y+ba-sy+3)*2,' ');
-            } else {
-                if( ((x+bb)>-1)     && ((y+ba)>-1) &&
-                ((x+bb)<ROWLEN) && ((y+ba)<NOOFROWS) ) {
-                    move(y+ba+1,x+bb+1);
-                        addch(' ');
+    for (ba = -1; ba < 2; ba++)
+        for (bb = -1; bb < 2; bb++)
+        {
+            if (screen[y + ba][x + bb] == '#')
+                continue;
+            if (!debug_disp)
+            {
+                if (((y + ba) < (sy + 4)) && ((y + ba) > (sy - 4))
+                    && ((x + bb) > (sx - 6)) && ((x + bb) < (sx + 6))
+                    && (y + ba > -1) && (x + bb > -1) && ((x + bb) < ROWLEN)
+                    && ((y + ba) < NOOFROWS))
+                    draw_symbol((x + bb - sx + 5) * 3, (y + ba - sy + 3) * 2,
+                                ' ');
+            }
+            else
+            {
+                if (((x + bb) > -1) && ((y + ba) > -1) && ((x + bb) < ROWLEN)
+                    && ((y + ba) < NOOFROWS))
+                {
+                    move(y + ba + 1, x + bb + 1);
+                    addch(' ');
                 }
             }
         }
 
     /* make all the necessary falling */
-    retval = check(mx,my,x-1,y-1,1,0,sx,sy,howdead);
-    retval += check(mx,my,x-1,y+1,0,-1,sx,sy,howdead);
-    retval += check(mx,my,x+1,y-1,0,1,sx,sy,howdead);
-    retval += check(mx,my,x+1,y+1,-1,0,sx,sy,howdead);
+    retval = check(mx, my, x - 1, y - 1, 1, 0, sx, sy, howdead);
+    retval += check(mx, my, x - 1, y + 1, 0, -1, sx, sy, howdead);
+    retval += check(mx, my, x + 1, y - 1, 0, 1, sx, sy, howdead);
+    retval += check(mx, my, x + 1, y + 1, -1, 0, sx, sy, howdead);
     return retval;
 }

--- a/fall.h
+++ b/fall.h
@@ -2,7 +2,8 @@
 #define __FALL_H
 
 int bang(int x, int y, int *mx, int *my, int sx, int sy, char *howdead);
-int check(int *mx, int *my, int x, int y, int dx, int dy, int sx, int sy, char howdead[25]);
+int check(int *mx, int *my, int x, int y, int dx, int dy, int sx,
+          int sy, char howdead[25]);
 int fall(int *mx, int *my, int x, int y, int sx, int sy, char howdead[25]);
 
 #endif // __FALL_H

--- a/game.c
+++ b/game.c
@@ -425,9 +425,9 @@ char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
                 addstr(buffer);
                 draw_symbol(50, 11, ' ');
                 move(12, 56);
-                addstr("              ");
+                printw("%14s", "");
                 move(13, 56);
-                addstr("              ");
+                printw("%14s", "");
                 move(16, 0);
                 refresh();
             }
@@ -514,9 +514,9 @@ char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
                 addstr(buffer);
                 draw_symbol(50, 11, ' ');
                 move(12, 56);
-                addstr("              ");
+                printw("%14s", "");
                 move(13, 56);
-                addstr("              ");
+                printw("%14s", "");
                 move(16, 0);
                 refresh();
             }
@@ -572,9 +572,9 @@ char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
                 addstr(buffer);
                 draw_symbol(50, 11, ' ');
                 move(12, 56);
-                addstr("              ");
+                printw("%14s", "");
                 move(13, 56);
-                addstr("              ");
+                printw("%14s", "");
                 move(16, 0);
                 refresh();
             }
@@ -772,9 +772,8 @@ char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
                 move(18, 0);
             else
                 move(20, 0);
-            addstr
-                ("                                                              ");
-            addstr("\n                      ");
+            printw("%62s", "");
+            printw("\n%22s", "");
             refresh();
         }
     }

--- a/game.c
+++ b/game.c
@@ -18,11 +18,12 @@ extern int debug_disp;
 extern int edit_mode;
 extern int saved_game;
 extern int record_file;
-extern char screen[NOOFROWS][ROWLEN+1];
+extern char screen[NOOFROWS][ROWLEN + 1];
 extern char *edit_memory;
 extern char *memory_end;
 
-struct mon_rec start_of_list = {0,0,0,0,0,NULL,NULL};
+struct mon_rec start_of_list = { 0, 0, 0, 0, 0, NULL, NULL };
+
 struct mon_rec *last_of_list, *tail_of_list;
 
 /*************************************************************** 
@@ -48,698 +49,734 @@ struct mon_rec *last_of_list, *tail_of_list;
 
 char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10])
 {
-    int  x,y,nx,ny,deadyet =0,
-         sx = -1,sy = -1,tx = -1,ty = -1,lx = 0,ly = 0,mx = -1,my = -1,
-         newnum, recording = 0, diamonds = 0, nf = 0, tmpx, tmpy;
-    char (*frow)[ROWLEN+1] = screen,
-         ch, *memory_ptr,
-         buffer[25];
+    int x, y, nx, ny, deadyet = 0, sx = -1, sy = -1, tx = -1, ty =
+        -1, lx = 0, ly = 0, mx = -1, my = -1, newnum, recording = 0, diamonds =
+        0, nf = 0, tmpx, tmpy;
+    char (*frow)[ROWLEN + 1] = screen, ch, *memory_ptr, buffer[25];
     struct mon_rec *monster;
-    static char     howdead[25];  /* M001 can't use auto var for return value */
+    static char howdead[25];    /* M001 can't use auto var for return value */
 
     tail_of_list = &start_of_list;
     memory_ptr = edit_memory;
 
-    for(x=0;x<=ROWLEN;x++)
-        for(y=0;y<NOOFROWS;y++)
+    for (x = 0; x <= ROWLEN; x++)
+        for (y = 0; y < NOOFROWS; y++)
         {
-            if((screen[y][x] == '*')||(screen[y][x] == '+'))
+            if ((screen[y][x] == '*') || (screen[y][x] == '+'))
                 diamonds++;
-            if(screen[y][x] == 'A')     /* note teleport arrival point &  */
-            {                       /* replace with space */
+            if (screen[y][x] == 'A')    /* note teleport arrival point &  */
+            {                   /* replace with space */
                 tx = x;
                 ty = y;
-                 screen[y][x] = ' ';
+                screen[y][x] = ' ';
             }
-            if(screen[y][x] == '@')
+            if (screen[y][x] == '@')
             {
                 sx = x;
                 sy = y;
             }
-            if(screen[y][x] == 'M')     /* Put megamonster in */
+            if (screen[y][x] == 'M')    /* Put megamonster in */
             {
                 mx = x;
                 my = y;
             }
-            if(screen[y][x] == 'S')   /* link small monster to pointer chain */
+            if (screen[y][x] == 'S')    /* link small monster to pointer chain */
             {
-            if((monster = make_monster(x,y)) == NULL)
-            {
-                strcpy(howdead,"running out of memory");
-                return howdead;
+                if ((monster = make_monster(x, y)) == NULL)
+                {
+                    strcpy(howdead, "running out of memory");
+                    return howdead;
+                }
+                if (!viable(x, y - 1))  /* make sure its running in the correct */
+                {               /* direction..                          */
+                    monster->mx = 1;
+                    monster->my = 0;
+                }
+                else if (!viable(x + 1, y))
+                {
+                    monster->mx = 0;
+                    monster->my = 1;
+                }
+                else if (!viable(x, y + 1))
+                {
+                    monster->mx = -1;
+                    monster->my = 0;
+                }
+                else if (!viable(x - 1, y))
+                {
+                    monster->mx = 0;
+                    monster->my = -1;
+                }
             }
-            if(!viable(x,y-1))     /* make sure its running in the correct */
-            {                  /* direction..                          */
-                monster->mx = 1;
-                monster->my = 0;
-            }
-            else if(!viable(x+1,y))
-            {
-                monster->mx = 0;
-                monster->my = 1;
-            }
-            else if(!viable(x,y+1))
-            {
-                monster->mx = -1;
-                monster->my = 0;
-            }
-            else if(!viable(x-1,y))
-            {
-                monster->mx = 0;
-                monster->my = -1;
-            }
-        }
-        if(screen[y][x] == '-')
+            if (screen[y][x] == '-')
                 screen[y][x] = ' ';
-    };
-    x=sx;
-    y=sy;
-    if((x == -1)&&(y == -1))              /* no start position in screen ? */
+        };
+    x = sx;
+    y = sy;
+    if ((x == -1) && (y == -1)) /* no start position in screen ? */
     {
-        strcpy(howdead,"a screen design error");
-        return(howdead);
+        strcpy(howdead, "a screen design error");
+        return (howdead);
     }
-    
-    if(maxmoves < 1) maxmoves = -1;
-    
-    update_game:        /* M002  restored game restarts here        */
-    
-    redraw_screen(bell,maxmoves,*num,*score,nf,diamonds,mx,sx,sy,frow);
-    
+
+    if (maxmoves < 1)
+        maxmoves = -1;
+
+  update_game:                 /* M002  restored game restarts here        */
+
+    redraw_screen(bell, maxmoves, *num, *score, nf, diamonds, mx, sx, sy,
+                  frow);
+
 /* ACTUAL GAME FUNCTION - Returns method of death in string  */
-    
-    while(deadyet == 0)
+
+    while (deadyet == 0)
     {
-        switch(recording)
+        switch (recording)
         {
-          case 1:
-              ch = getch();
-              *memory_ptr++ = ch;
-               memory_end++;
-               break;
-         case 2:
-              ch = *memory_ptr++;
-              if( ch == '\0' )
-                    ch = ')';
-              break;
-         default:
-              ch = getch();
+        case 1:
+            ch = getch();
+            *memory_ptr++ = ch;
+            memory_end++;
+            break;
+        case 2:
+            ch = *memory_ptr++;
+            if (ch == '\0')
+                ch = ')';
+            break;
+        default:
+            ch = getch();
         }
-        if((record_file != -1)&&(ch != 'q'))
-            if (write(record_file,&ch,1) == -1) {
+        if ((record_file != -1) && (ch != 'q'))
+            if (write(record_file, &ch, 1) == -1)
+            {
                 fprintf(stderr, "write error\n");
                 exit(EXIT_FAILURE);
             }
-        
-        nx=x;
-        ny=y;
-        
-        if((ch == keys[3]) && (x <(ROWLEN-1)))
-                        /* move about - but thats obvious */
+
+        nx = x;
+        ny = y;
+
+        if ((ch == keys[3]) && (x < (ROWLEN - 1)))
+            /* move about - but thats obvious */
             nx++;
-        if((ch == keys[2]) && (x > 0))
+        if ((ch == keys[2]) && (x > 0))
             nx--;
-        if((ch == keys[1]) && (y <(NOOFROWS-1)))
+        if ((ch == keys[1]) && (y < (NOOFROWS - 1)))
             ny++;
-        if((ch == keys[0]) && (y > 0))
+        if ((ch == keys[0]) && (y > 0))
             ny--;
-        if(ch == '1')                  /* Add or get rid of that awful sound */
+        if (ch == '1')          /* Add or get rid of that awful sound */
         {
-            move(17,56);
+            move(17, 56);
             *bell = 1;
             addstr("Bell ON ");
-            move(16,0);
+            move(16, 0);
             refresh();
             continue;
         }
-        if(ch == '0')
+        if (ch == '0')
         {
             *bell = 0;
-            move(17,56);
+            move(17, 56);
             addstr("Bell OFF");
-            move(16,0);
+            move(16, 0);
             refresh();
             continue;
         }
-        if(ch == '~')                             /* level jump */
+        if (ch == '~')          /* level jump */
         {
-            if(edit_mode)
+            if (edit_mode)
                 continue;
-            if((newnum = jumpscreen(*num)) == 0)
+            if ((newnum = jumpscreen(*num)) == 0)
             {
-                strcpy(howdead,"a jump error.");
+                strcpy(howdead, "a jump error.");
                 return howdead;
             }
-            if(newnum != *num)
+            if (newnum != *num)
             {                   /* Sorry Greg, no points for free */
-                sprintf(howdead,"~%c",newnum);
+                sprintf(howdead, "~%c", newnum);
                 return howdead;
             }
             continue;
         }
-        if(ch == '!')                      /* look at the map */
+        if (ch == '!')          /* look at the map */
         {
-            if(debug_disp)
+            if (debug_disp)
                 continue;
             map(frow);
             display(sx, sy, frow);
             continue;
         }
-        if(ch == 'q')
+        if (ch == 'q')
         {
-            strcpy(howdead,"quitting the game");
+            strcpy(howdead, "quitting the game");
             return howdead;
         }
-        if(ch == '?')
+        if (ch == '?')
         {
             helpme(1);
-            if(debug_disp)
+            if (debug_disp)
                 map(frow);
             else
                 display(sx, sy, frow);
             continue;
         }
-        if((ch == '@')&&(!debug_disp))
+        if ((ch == '@') && (!debug_disp))
         {
             sx = x;
             sy = y;
             display(sx, sy, frow);
             continue;
         }
-        if(ch == '#')
+        if (ch == '#')
         {
             debug_disp = 1 - debug_disp;
-            if(debug_disp)
-                    map(frow);
+            if (debug_disp)
+                map(frow);
             else
             {
-                     for(tmpy=0;tmpy<=(NOOFROWS+1);tmpy++)
-                     {
-                            move(tmpy,0);
-                            for(tmpx=0;tmpx<=(ROWLEN+2);tmpx++)
-                                        addch(' ');
-                     }
-                    sx = x; sy = y;
-                    display(sx, sy, frow);
+                for (tmpy = 0; tmpy <= (NOOFROWS + 1); tmpy++)
+                {
+                    move(tmpy, 0);
+                    for (tmpx = 0; tmpx <= (ROWLEN + 2); tmpx++)
+                        addch(' ');
+                }
+                sx = x;
+                sy = y;
+                display(sx, sy, frow);
             }
             continue;
         }
-        if((ch == 'W') || ( (int)ch == 12 ))
+        if ((ch == 'W') || ((int) ch == 12))
         {
-            redraw_screen(bell,maxmoves,*num,*score,nf,diamonds,mx,sx,sy,frow);
+            redraw_screen(bell, maxmoves, *num, *score, nf, diamonds, mx, sx,
+                          sy, frow);
             continue;
         }
-    
-    /* Edit screen memory functions */
-        if(edit_memory)
+
+        /* Edit screen memory functions */
+        if (edit_memory)
         {
-            if((ch == '(') && (recording == 0)) 
-                                      /* start recording from beginning */
+            if ((ch == '(') && (recording == 0))
+                /* start recording from beginning */
             {
                 memory_end = memory_ptr = edit_memory;
-                move(10,53);
+                move(10, 53);
                 addstr(" -Recording-");
                 refresh();
                 recording = 1;
                 continue;
             }
-            if((ch == ')') && ( recording != 0 ))
-                                         /* stop recording or playback */
+            if ((ch == ')') && (recording != 0))
+                /* stop recording or playback */
             {
                 recording = 0;
-                move(10,53);
+                move(10, 53);
                 addstr(" -- End --  ");
                 refresh();
-                move(10,53);
+                move(10, 53);
                 addstr(" -Occupied- ");
                 continue;
             }
-            if((ch == '*') && (recording == 0))  /* playback memory */
+            if ((ch == '*') && (recording == 0))        /* playback memory */
             {
                 memory_ptr = edit_memory;
                 recording = 2;
-                move(10,53);
+                move(10, 53);
                 addstr(" -Playback- ");
                 refresh();
                 continue;
             }
-            if((ch == '&') && (recording == 0))/* extend recording,either from*/
-            {                                /* end or from checkpoint        */
+            if ((ch == '&') && (recording == 0))        /* extend recording,either from */
+            {                   /* end or from checkpoint        */
                 recording = 1;
-                move(10,53);
+                move(10, 53);
                 addstr(" -Recording-");
                 refresh();
-                if(*(memory_ptr -1) != '-')
-                        memory_ptr--;
+                if (*(memory_ptr - 1) != '-')
+                    memory_ptr--;
                 continue;
             }
-            if((ch == '+') && (recording == 0) && (memory_ptr < memory_end))
+            if ((ch == '+') && (recording == 0) && (memory_ptr < memory_end))
             {
-            /* continue from checkpoint */
+                /* continue from checkpoint */
                 recording = 2;
-                move(10,53);
+                move(10, 53);
                 addstr(" -Playback- ");
                 refresh();
                 continue;
             }
-            if(( ch == '-') && (recording != 0)) 
-                                            /*create or react to a checkpoint*/
+            if ((ch == '-') && (recording != 0))
+                /*create or react to a checkpoint */
             {
-            /* checkpoint */
-                move(10,53);
+                /* checkpoint */
+                move(10, 53);
                 addstr("-Checkpoint-");
                 refresh();
-                move(10,53);
-                if( recording == 2)
+                move(10, 53);
+                if (recording == 2)
                 {
                     recording = 0;
                     addstr(" -Occupied- ");
-                } else addstr(" -Recording-");
+                }
+                else
+                    addstr(" -Recording-");
                 continue;
             }
         }
         /* end of memory functions */
-        
+
         /* M002  Added save/restore game feature.  Gregory H. Margo        */
-        if(ch == 'S')           /* save game */
+        if (ch == 'S')          /* save game */
         {
-                extern        struct        save_vars        zz;
-        
+            extern struct save_vars zz;
+
             /* stuff away important local variables to be saved */
             /* so the game state may be acurately restored        */
-                zz.z_x                = x;
-                zz.z_y                = y;
-                zz.z_sx                = sx;
-                zz.z_sy                = sy;
-                zz.z_tx                = tx;
-                zz.z_ty                = ty;
-                zz.z_mx                = mx;
-                zz.z_my                = my;
-                zz.z_diamonds        = diamonds;
-                zz.z_nf                = nf;
-        
-                save_game(*num, score, bell, maxmoves);
-                /* NOTREACHED ... unless there's been an error. */
+            zz.z_x = x;
+            zz.z_y = y;
+            zz.z_sx = sx;
+            zz.z_sy = sy;
+            zz.z_tx = tx;
+            zz.z_ty = ty;
+            zz.z_mx = mx;
+            zz.z_my = my;
+            zz.z_diamonds = diamonds;
+            zz.z_nf = nf;
+
+            save_game(*num, score, bell, maxmoves);
+            /* NOTREACHED ... unless there's been an error. */
         }
-        if(ch == 'R')            /* restore game */
+        if (ch == 'R')          /* restore game */
         {
-                extern        struct        save_vars        zz;
-        
-                restore_game(num, score, bell, &maxmoves);
-        
-                /* recover important local variables */
-                x                = zz.z_x;
-                y                = zz.z_y;
-                sx                = zz.z_sx;
-                sy                = zz.z_sy;
-                tx                = zz.z_tx;
-                ty                = zz.z_ty;
-                mx                = zz.z_mx;
-                my                = zz.z_my;
-                diamonds        = zz.z_diamonds;
-                nf                = zz.z_nf;
-        
-                goto update_game;        /* the dreaded goto        */
+            extern struct save_vars zz;
+
+            restore_game(num, score, bell, &maxmoves);
+
+            /* recover important local variables */
+            x = zz.z_x;
+            y = zz.z_y;
+            sx = zz.z_sx;
+            sy = zz.z_sy;
+            tx = zz.z_tx;
+            ty = zz.z_ty;
+            mx = zz.z_mx;
+            my = zz.z_my;
+            diamonds = zz.z_diamonds;
+            nf = zz.z_nf;
+
+            goto update_game;   /* the dreaded goto        */
         }
-        
-        if(screen[ny][nx] == 'C')
+
+        if (screen[ny][nx] == 'C')
         {
             screen[ny][nx] = ':';
-            *score+=4;
-            if(maxmoves != -1)
-                maxmoves+=250;
+            *score += 4;
+            if (maxmoves != -1)
+                maxmoves += 250;
         }
-        switch(screen[ny][nx])
+        switch (screen[ny][nx])
         {
-            case '@': break;
-            case '*': *score+=9;
-                nf++;
-        #ifdef NOISY
-                if(*bell)printf("\007");
-        #endif
-            case ':': *score+=1;
-                move(3,48);
-                sprintf(buffer,"%ld\t %d",*score,nf);
+        case '@':
+            break;
+        case '*':
+            *score += 9;
+            nf++;
+#ifdef NOISY
+            if (*bell)
+                printf("\007");
+#endif
+        case ':':
+            *score += 1;
+            move(3, 48);
+            sprintf(buffer, "%ld\t %d", *score, nf);
+            addstr(buffer);
+        case ' ':
+            screen[y][x] = ' ';
+            screen[ny][nx] = '@';
+            if (!debug_disp)
+            {
+                draw_symbol((x - sx + 5) * 3, (y - sy + 3) * 2, ' ');
+                draw_symbol((nx - sx + 5) * 3, (ny - sy + 3) * 2, '@');
+            }
+            else
+            {
+                move(y + 1, x + 1);
+                addch(' ');
+                move(ny + 1, nx + 1);
+                addch('@');
+            }
+            deadyet += check(&mx, &my, x, y, nx - x, ny - y, sx, sy, howdead);
+            move(16, 0);
+            refresh();
+            y = ny;
+            x = nx;
+            break;
+        case 'O':
+            if ((nx == 0) || (nx == ROWLEN))
+                break;
+            if (screen[y][nx * 2 - x] == 'M')
+            {
+                screen[y][nx * 2 - x] = ' ';
+                mx = my = -1;
+                *score += 100;
+                move(3, 48);
+                sprintf(buffer, "%ld\t %d\t %d ", *score, nf, diamonds);
                 addstr(buffer);
-            case ' ':
+                draw_symbol(50, 11, ' ');
+                move(12, 56);
+                addstr("              ");
+                move(13, 56);
+                addstr("              ");
+                move(16, 0);
+                refresh();
+            }
+            if (screen[y][nx * 2 - x] == ' ')
+            {
+                screen[y][nx * 2 - x] = 'O';
                 screen[y][x] = ' ';
-                   screen[ny][nx] = '@';
-                if(!debug_disp)
+                screen[ny][nx] = '@';
+                if (!debug_disp)
                 {
-                    draw_symbol((x-sx+5)*3,(y-sy+3)*2,' ');
-                    draw_symbol((nx-sx+5)*3,(ny-sy+3)*2,'@');
+                    draw_symbol((x - sx + 5) * 3, (y - sy + 3) * 2, ' ');
+                    draw_symbol((nx - sx + 5) * 3, (ny - sy + 3) * 2, '@');
+                    if (nx * 2 - x > sx - 6 && nx * 2 - x < sx + 6)
+                        draw_symbol((nx * 2 - x - sx + 5) * 3,
+                                    (y - sy + 3) * 2, 'O');
                 }
                 else
                 {
-                    move(y+1,x+1);
+                    move(y + 1, x + 1);
                     addch(' ');
-                    move(ny+1,nx+1);
+                    move(ny + 1, nx + 1);
                     addch('@');
+                    move(y + 1, nx * 2 - x + 1);
+                    addch('O');
                 }
-                deadyet += check(&mx,&my,x,y,nx-x,ny-y,sx,sy,howdead);
-                move(16,0);
+                deadyet += fall(&mx, &my, nx * 2 - x, y + 1, sx, sy, howdead);
+                deadyet += fall(&mx, &my, x * 2 - nx, y, sx, sy, howdead);
+                deadyet += fall(&mx, &my, x, y, sx, sy, howdead);
+                deadyet += fall(&mx, &my, x, y - 1, sx, sy, howdead);
+                deadyet += fall(&mx, &my, x, y + 1, sx, sy, howdead);
+                move(16, 0);
                 refresh();
                 y = ny;
                 x = nx;
+            }
+            break;
+        case '^':
+            if ((nx == 0) || (nx == ROWLEN))
                 break;
-            case 'O':
-                if((nx == 0 )||(nx == ROWLEN)) break;
-                if(screen[y][nx*2-x] == 'M')
+            if (screen[y][nx * 2 - x] == ' ')
+            {
+                screen[y][nx * 2 - x] = '^';
+                screen[y][x] = ' ';
+                screen[ny][nx] = '@';
+                if (!debug_disp)
                 {
-                    screen[y][nx*2-x] = ' ';
-                    mx = my = -1;
-                    *score+=100;
-                    move(3,48);
-                    sprintf(buffer,"%ld\t %d\t %d ",*score,nf,diamonds);
-                    addstr(buffer);
-                    draw_symbol(50,11,' ');
-                    move(12,56); addstr("              ");
-                        move(13,56); addstr("              ");
-                    move(16,0);
-                    refresh();
-                }
-                if(screen[y][nx*2-x] == ' ')
-                {
-                    screen[y][nx*2-x] = 'O';
-                    screen[y][x] = ' ';
-                    screen[ny][nx] = '@';
-                    if(!debug_disp)
-                    {
-                        draw_symbol((x-sx+5)*3,(y-sy+3)*2,' ');
-                        draw_symbol((nx-sx+5)*3,(ny-sy+3)*2,'@');
-                        if(nx*2-x>sx-6&&nx*2-x<sx+6)
-                            draw_symbol((nx*2-x-sx+5)*3,(y-sy+3)*2,'O');
-                    }
-                    else
-                    {
-                        move(y+1,x+1);
-                        addch(' ');
-                        move(ny+1,nx+1);
-                        addch('@');
-                        move(y+1,nx*2-x+1);
-                        addch('O');
-                    }
-                    deadyet += fall(&mx,&my,nx*2-x,y+1,sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x*2-nx,y,sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x,y,sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x,y-1,sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x,y+1,sx,sy,howdead);
-                    move(16,0);
-                    refresh();
-                    y = ny;
-                    x = nx;
-                }
-                break;
-            case '^':
-                if((nx == 0 )||(nx == ROWLEN)) break;
-                if(screen[y][nx*2-x] == ' ')
-                {
-                    screen[y][nx*2-x] = '^';
-                    screen[y][x] = ' ';
-                    screen[ny][nx] = '@';
-                    if(!debug_disp)
-                    {
-                        draw_symbol((x-sx+5)*3,(y-sy+3)*2,' ');
-                        draw_symbol((nx-sx+5)*3,(ny-sy+3)*2,'@');
-                        if(nx*2-x>sx-6&&nx*2-x<sx+6)
-                            draw_symbol((nx*2-x-sx+5)*3,(y-sy+3)*2,'^');
-                    }
-                    else
-                    {
-                        move(y+1,x+1);
-                        addch(' ');
-                        move(ny+1,nx+1);
-                        addch('@');
-                        move(y+1,nx*2-x+1);
-                        addch('^');
-                    }
-                    deadyet += fall(&mx,&my,nx*2-x,y-1,sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x*2-nx,y,sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x,y,sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x,y+1,sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x,y-1,sx,sy,howdead);
-                    move(16,0);
-                    refresh();
-                    y = ny;
-                    x = nx;
-                }
-                break;
-            case '<':
-            case '>':
-                if((ny == 0) || ( ny == NOOFROWS)) break;
-                if(screen[ny*2-y][x] == 'M')
-                {
-                    screen[ny*2-y][x] = ' ';
-                    mx = my = -1;
-                    *score+=100;
-                    move(3,48);
-                    sprintf(buffer,"%ld\t %d\t %d ",*score,nf,diamonds);
-                    addstr(buffer);
-                    draw_symbol(50,11,' ');
-                       move(12,56); addstr("              ");
-                      move(13,56); addstr("              ");
-                    move(16,0);
-                    refresh();
-                }
-                if(screen[ny*2-y][x] == ' ')
-                {
-                    screen[ny*2-y][x] = screen[ny][nx];
-                    screen[y][x] = ' ';
-                    screen[ny][nx] = '@';
-                    if(!debug_disp)
-                    {
-                        draw_symbol((x-sx+5)*3,(y-sy+3)*2,' ');
-                        draw_symbol((nx-sx+5)*3,(ny-sy+3)*2,'@');
-                        if(ny*2-y>sy-4&&ny*2-y<sy+4)
-                            draw_symbol((x-sx+5)*3,(ny*2-y-sy+3)*2,screen[ny*2-y][x]);
-                    }
-                    else
-                    {
-                        move(y+1,x+1);
-                        addch(' ');
-                        move(ny+1,nx+1);
-                        addch('@');
-                        move(ny*2-y+1,x+1);
-                        addch(screen[ny*2-y][x]);
-                    }
-                    deadyet += fall(&mx,&my,x,y,sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x-1,(ny>y)?y:(y-1),sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x+1,(ny>y)?y:(y-1),sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x-1,ny*2-y,sx,sy,howdead);
-                    deadyet += fall(&mx,&my,x+1,ny*2-y,sx,sy,howdead);
-                    move(16,0);
-                    refresh();
-                    y = ny;
-                    x = nx;
-                    }
-                break;
-            case '~':
-                if(((2*nx-x) < 0) ||((ny*2-y) > NOOFROWS)||((ny*2-y) < 0)||((2*nx-x) > ROWLEN)) break;
-                if(screen[ny*2-y][nx*2 -x] == 'M')
-                {
-                    screen[ny*2-y][nx*2-x] = ' ';
-                    mx = my = -1;
-                    *score+=100;
-                    move(3,48);
-                    sprintf(buffer,"%ld\t %d\t %d ",*score,nf,diamonds);
-                    addstr(buffer);
-                    draw_symbol(50,11,' ');
-                       move(12,56); addstr("              ");
-                      move(13,56); addstr("              ");
-                    move(16,0);
-                    refresh();
-                }
-                if(screen[ny*2-y][nx*2-x] == ' ')
-                {
-                    screen[ny*2-y][nx*2-x] = '~';
-                    screen[y][x] = ' ';
-                    screen[ny][nx] = '@';
-                    if(!debug_disp)
-                    {
-                        draw_symbol((x-sx+5)*3,(y-sy+3)*2,' ');
-                        draw_symbol((nx-sx+5)*3,(ny-sy+3)*2,'@');
-                        if((ny*2-y>sy-4)&&(ny*2-y<sy+4))
-                            draw_symbol((nx*2-x-sx+5)*3,(ny*2-y-sy+3)*2,'~');
-                    }
-                    else
-                    {
-                        move(y+1,x+1);
-                        addch(' ');
-                        move(ny+1,nx+1);
-                        addch('@');
-                        move(ny*2-y+1,nx*2-x+1);
-                        addch('~');
-                    }
-                    deadyet += check(&mx,&my,x,y,nx-x,ny-y,sx,sy,howdead);
-                    move(16,0); refresh();
-                    y = ny; x = nx;
-                }
-                break;
-            case '!':
-                strcpy(howdead,"an exploding landmine");
-                deadyet = 1;
-                if(!debug_disp)
-                {
-                        draw_symbol((x-sx+5)*3,(y-sy+3)*2,' ');
-                        draw_symbol((nx-sx+5)*3,(ny-sy+3)*2,'%');
+                    draw_symbol((x - sx + 5) * 3, (y - sy + 3) * 2, ' ');
+                    draw_symbol((nx - sx + 5) * 3, (ny - sy + 3) * 2, '@');
+                    if (nx * 2 - x > sx - 6 && nx * 2 - x < sx + 6)
+                        draw_symbol((nx * 2 - x - sx + 5) * 3,
+                                    (y - sy + 3) * 2, '^');
                 }
                 else
                 {
-                    move(y+1,x+1);
+                    move(y + 1, x + 1);
                     addch(' ');
-                    move(ny+1,nx+1);
+                    move(ny + 1, nx + 1);
                     addch('@');
+                    move(y + 1, nx * 2 - x + 1);
+                    addch('^');
                 }
-                move(16,0);
+                deadyet += fall(&mx, &my, nx * 2 - x, y - 1, sx, sy, howdead);
+                deadyet += fall(&mx, &my, x * 2 - nx, y, sx, sy, howdead);
+                deadyet += fall(&mx, &my, x, y, sx, sy, howdead);
+                deadyet += fall(&mx, &my, x, y + 1, sx, sy, howdead);
+                deadyet += fall(&mx, &my, x, y - 1, sx, sy, howdead);
+                move(16, 0);
                 refresh();
+                y = ny;
+                x = nx;
+            }
+            break;
+        case '<':
+        case '>':
+            if ((ny == 0) || (ny == NOOFROWS))
                 break;
-            case 'X':
-                if(nf == diamonds)
+            if (screen[ny * 2 - y][x] == 'M')
+            {
+                screen[ny * 2 - y][x] = ' ';
+                mx = my = -1;
+                *score += 100;
+                move(3, 48);
+                sprintf(buffer, "%ld\t %d\t %d ", *score, nf, diamonds);
+                addstr(buffer);
+                draw_symbol(50, 11, ' ');
+                move(12, 56);
+                addstr("              ");
+                move(13, 56);
+                addstr("              ");
+                move(16, 0);
+                refresh();
+            }
+            if (screen[ny * 2 - y][x] == ' ')
+            {
+                screen[ny * 2 - y][x] = screen[ny][nx];
+                screen[y][x] = ' ';
+                screen[ny][nx] = '@';
+                if (!debug_disp)
                 {
-                    *score+=250;
-                    showpass(*num);
-                    return NULL;
-                }
-                break;
-            case 'T':
-                if(tx > -1)
-                {
-                    screen[ny][nx] = ' ';
-                    screen[y][x] = ' ';
-                    lx = x;
-                    ly = y;
-                    y = ty;
-                    x = tx;
-                    screen[y][x] = '@';
-                    sx = x;
-                    sy = y;
-                    *score += 20;
-                    move(3,48);
-                    sprintf(buffer,"%ld\t %d\t %d ",*score,nf,diamonds);
-                    addstr(buffer);
-                    if(!debug_disp)
-                        display(sx, sy, frow);
-                    else
-                        map(frow);
-                    deadyet += fall(&mx,&my,nx,ny,sx,sy,howdead);
-                    if(deadyet == 0)
-                        deadyet = fall(&mx,&my,lx,ly,sx,sy,howdead);
-                    if(deadyet == 0)
-                        deadyet = fall(&mx,&my,lx+1,ly-1,sx,sy,howdead);
-                    if(deadyet == 0)
-                        deadyet = fall(&mx,&my,lx+1,ly+1,sx,sy,howdead);
-                    if(deadyet == 0)
-                        deadyet = fall(&mx,&my,lx-1,ly+1,sx,sy,howdead);
-                    if(deadyet == 0)
-                        deadyet = fall(&mx,&my,lx-1,ly-1,sx,sy,howdead);
-                    move(16,0);
-                    refresh();
+                    draw_symbol((x - sx + 5) * 3, (y - sy + 3) * 2, ' ');
+                    draw_symbol((nx - sx + 5) * 3, (ny - sy + 3) * 2, '@');
+                    if (ny * 2 - y > sy - 4 && ny * 2 - y < sy + 4)
+                        draw_symbol((x - sx + 5) * 3,
+                                    (ny * 2 - y - sy + 3) * 2,
+                                    screen[ny * 2 - y][x]);
                 }
                 else
                 {
-                    screen[ny][nx] = ' ';
-                    printf("Teleport out of order");
-                }
-                break;
-            case 'M':
-                strcpy(howdead,"a hungry monster");
-                deadyet = 1;
-                if(!debug_disp)
-                        draw_symbol((x-sx+5)*3,(y-sy+3)*2,' ');
-                else
-                {
-                    move(y+1,x+1);
+                    move(y + 1, x + 1);
                     addch(' ');
+                    move(ny + 1, nx + 1);
+                    addch('@');
+                    move(ny * 2 - y + 1, x + 1);
+                    addch(screen[ny * 2 - y][x]);
                 }
-                move(16,0);
+                deadyet += fall(&mx, &my, x, y, sx, sy, howdead);
+                deadyet +=
+                    fall(&mx, &my, x - 1, (ny > y) ? y : (y - 1), sx, sy,
+                         howdead);
+                deadyet +=
+                    fall(&mx, &my, x + 1, (ny > y) ? y : (y - 1), sx, sy,
+                         howdead);
+                deadyet += fall(&mx, &my, x - 1, ny * 2 - y, sx, sy, howdead);
+                deadyet += fall(&mx, &my, x + 1, ny * 2 - y, sx, sy, howdead);
+                move(16, 0);
                 refresh();
+                y = ny;
+                x = nx;
+            }
+            break;
+        case '~':
+            if (((2 * nx - x) < 0) || ((ny * 2 - y) > NOOFROWS)
+                || ((ny * 2 - y) < 0) || ((2 * nx - x) > ROWLEN))
                 break;
-            case 'S':
-                strcpy(howdead,"walking into a monster");
-                deadyet = 1;
-                if(!debug_disp)
-                        draw_symbol((x-sx+5)*3,(y-sy+3)*2,' ');
+            if (screen[ny * 2 - y][nx * 2 - x] == 'M')
+            {
+                screen[ny * 2 - y][nx * 2 - x] = ' ';
+                mx = my = -1;
+                *score += 100;
+                move(3, 48);
+                sprintf(buffer, "%ld\t %d\t %d ", *score, nf, diamonds);
+                addstr(buffer);
+                draw_symbol(50, 11, ' ');
+                move(12, 56);
+                addstr("              ");
+                move(13, 56);
+                addstr("              ");
+                move(16, 0);
+                refresh();
+            }
+            if (screen[ny * 2 - y][nx * 2 - x] == ' ')
+            {
+                screen[ny * 2 - y][nx * 2 - x] = '~';
+                screen[y][x] = ' ';
+                screen[ny][nx] = '@';
+                if (!debug_disp)
+                {
+                    draw_symbol((x - sx + 5) * 3, (y - sy + 3) * 2, ' ');
+                    draw_symbol((nx - sx + 5) * 3, (ny - sy + 3) * 2, '@');
+                    if ((ny * 2 - y > sy - 4) && (ny * 2 - y < sy + 4))
+                        draw_symbol((nx * 2 - x - sx + 5) * 3,
+                                    (ny * 2 - y - sy + 3) * 2, '~');
+                }
                 else
                 {
-                    move(y+1,x+1);
+                    move(y + 1, x + 1);
                     addch(' ');
+                    move(ny + 1, nx + 1);
+                    addch('@');
+                    move(ny * 2 - y + 1, nx * 2 - x + 1);
+                    addch('~');
                 }
-                move(16,0);
+                deadyet +=
+                    check(&mx, &my, x, y, nx - x, ny - y, sx, sy, howdead);
+                move(16, 0);
                 refresh();
-                break;
-            default:
-                break;
+                y = ny;
+                x = nx;
+            }
+            break;
+        case '!':
+            strcpy(howdead, "an exploding landmine");
+            deadyet = 1;
+            if (!debug_disp)
+            {
+                draw_symbol((x - sx + 5) * 3, (y - sy + 3) * 2, ' ');
+                draw_symbol((nx - sx + 5) * 3, (ny - sy + 3) * 2, '%');
+            }
+            else
+            {
+                move(y + 1, x + 1);
+                addch(' ');
+                move(ny + 1, nx + 1);
+                addch('@');
+            }
+            move(16, 0);
+            refresh();
+            break;
+        case 'X':
+            if (nf == diamonds)
+            {
+                *score += 250;
+                showpass(*num);
+                return NULL;
+            }
+            break;
+        case 'T':
+            if (tx > -1)
+            {
+                screen[ny][nx] = ' ';
+                screen[y][x] = ' ';
+                lx = x;
+                ly = y;
+                y = ty;
+                x = tx;
+                screen[y][x] = '@';
+                sx = x;
+                sy = y;
+                *score += 20;
+                move(3, 48);
+                sprintf(buffer, "%ld\t %d\t %d ", *score, nf, diamonds);
+                addstr(buffer);
+                if (!debug_disp)
+                    display(sx, sy, frow);
+                else
+                    map(frow);
+                deadyet += fall(&mx, &my, nx, ny, sx, sy, howdead);
+                if (deadyet == 0)
+                    deadyet = fall(&mx, &my, lx, ly, sx, sy, howdead);
+                if (deadyet == 0)
+                    deadyet = fall(&mx, &my, lx + 1, ly - 1, sx, sy, howdead);
+                if (deadyet == 0)
+                    deadyet = fall(&mx, &my, lx + 1, ly + 1, sx, sy, howdead);
+                if (deadyet == 0)
+                    deadyet = fall(&mx, &my, lx - 1, ly + 1, sx, sy, howdead);
+                if (deadyet == 0)
+                    deadyet = fall(&mx, &my, lx - 1, ly - 1, sx, sy, howdead);
+                move(16, 0);
+                refresh();
+            }
+            else
+            {
+                screen[ny][nx] = ' ';
+                printf("Teleport out of order");
+            }
+            break;
+        case 'M':
+            strcpy(howdead, "a hungry monster");
+            deadyet = 1;
+            if (!debug_disp)
+                draw_symbol((x - sx + 5) * 3, (y - sy + 3) * 2, ' ');
+            else
+            {
+                move(y + 1, x + 1);
+                addch(' ');
+            }
+            move(16, 0);
+            refresh();
+            break;
+        case 'S':
+            strcpy(howdead, "walking into a monster");
+            deadyet = 1;
+            if (!debug_disp)
+                draw_symbol((x - sx + 5) * 3, (y - sy + 3) * 2, ' ');
+            else
+            {
+                move(y + 1, x + 1);
+                addch(' ');
+            }
+            move(16, 0);
+            refresh();
+            break;
+        default:
+            break;
         }
-        if((y == ny) && (x == nx) && (maxmoves>0))
+        if ((y == ny) && (x == nx) && (maxmoves > 0))
         {
-            sprintf(buffer,"Moves remaining = %d ",--maxmoves);
-            move(15,48);
+            sprintf(buffer, "Moves remaining = %d ", --maxmoves);
+            move(15, 48);
             addstr(buffer);
         }
-        if(maxmoves == 0)
+        if (maxmoves == 0)
         {
-            strcpy(howdead,"running out of time");
+            strcpy(howdead, "running out of time");
             deadyet = 1;
-            if(edit_mode) maxmoves = -1;
+            if (edit_mode)
+                maxmoves = -1;
         }
-        if(!debug_disp)
+        if (!debug_disp)
         {
-            if ((x<(sx-3))&& (deadyet ==0))  /* screen scrolling if necessary */
+            if ((x < (sx - 3)) && (deadyet == 0))       /* screen scrolling if necessary */
             {
-                sx-=6;
-                if(sx < 4)
+                sx -= 6;
+                if (sx < 4)
                     sx = 4;
                 display(sx, sy, frow);
             }
-            if ((y<(sy-2))&& (deadyet == 0))
+            if ((y < (sy - 2)) && (deadyet == 0))
             {
-                sy-=5;
-                if(sy < 2)
+                sy -= 5;
+                if (sy < 2)
                     sy = 2;
                 display(sx, sy, frow);
             }
-            if ((x>(sx+3)) && (!deadyet))
+            if ((x > (sx + 3)) && (!deadyet))
             {
-                sx+=6;
-                if(sx>(ROWLEN -5))
-                    sx = ROWLEN -5;
+                sx += 6;
+                if (sx > (ROWLEN - 5))
+                    sx = ROWLEN - 5;
                 display(sx, sy, frow);
             }
-            if ((y>(sy+2))&& (!deadyet))
+            if ((y > (sy + 2)) && (!deadyet))
             {
-                sy+=5;
-                if(sy > (NOOFROWS-3))
-                    sy = NOOFROWS -3;
+                sy += 5;
+                if (sy > (NOOFROWS - 3))
+                    sy = NOOFROWS - 3;
                 display(sx, sy, frow);
             }
         }
-        
-        deadyet += move_monsters(&mx,&my,score,howdead,sx,sy,nf,*bell,x,y,diamonds);
-        
-        if((edit_mode)&&(deadyet))         /* stop death if testing */
+
+        deadyet +=
+            move_monsters(&mx, &my, score, howdead, sx, sy, nf, *bell, x, y,
+                          diamonds);
+
+        if ((edit_mode) && (deadyet))   /* stop death if testing */
         {
             recording = 0;
-            move(10,53);
+            move(10, 53);
             addstr("-Occupied- ");
-            if(!debug_disp)
-                move(18,0);
+            if (!debug_disp)
+                move(18, 0);
             else
-                move(20,0);
+                move(20, 0);
             addstr("You were killed by ");
             addstr(howdead);
             addstr("\nPress 'c' to continue.");
             refresh();
-            ch=getch();
-            if(ch == 'c')
+            ch = getch();
+            if (ch == 'c')
                 deadyet = 0;
-            if(!debug_disp)
-                move(18,0);
-             else
-                move(20,0);
-            addstr("                                                              ");
+            if (!debug_disp)
+                move(18, 0);
+            else
+                move(20, 0);
+            addstr
+                ("                                                              ");
             addstr("\n                      ");
             refresh();
         }
     }
-    return(howdead);
+    return (howdead);
 }

--- a/game.h
+++ b/game.h
@@ -1,6 +1,7 @@
 #ifndef __GAME_H
 #define __GAME_H
 
-char *playscreen(int *num, long *score, int *bell, int maxmoves, char keys[10]);
+char *playscreen(int *num, long *score, int *bell, int maxmoves,
+                 char keys[10]);
 
 #endif // __GAME_H

--- a/help.c
+++ b/help.c
@@ -4,279 +4,281 @@
 #include "wand_head.h"
 #include <curses.h>
 
-char *help[]={
-"      **  W A N D E R E R  **      ", /* 0 */
-"    ===========================    ", /* 1 */
-"        by Steven Shipway          ", /* 2 */
-"How to play:                       ", /* 3 */
-" Collect all the treasure:    /$\\  ", /* 4 */
-"                              \\$/  ", /* 5 */
-" Then go through the exit:    Way  ", /* 6 */
-"                              out  ", /* 7 */
-"  h  Left       j  Down            ", /* 8 */
-"  k  Up         l  Right           ", /* 9 */
+char *help[] = {
+    "      **  W A N D E R E R  **      ",      /* 0 */
+    "    ===========================    ",      /* 1 */
+    "        by Steven Shipway          ",      /* 2 */
+    "How to play:                       ",      /* 3 */
+    " Collect all the treasure:    /$\\  ",     /* 4 */
+    "                              \\$/  ",     /* 5 */
+    " Then go through the exit:    Way  ",      /* 6 */
+    "                              out  ",      /* 7 */
+    "  h  Left       j  Down            ",      /* 8 */
+    "  k  Up         l  Right           ",      /* 9 */
 #ifdef NOISY
-"  1  Loud       q  Quit game       ", /* 10 */
-"  0  Quiet      !  Look at map     ", /* 11 */
-"  S  Save game  R  Restore Game    ", /* 12 */
-"  ?  Help mode  @  Center screen   ", /* 13 */
-"  ~  Jump level #  Switch mode     ", /* 14 */
-" (no bonus)     W,^L Redraw screen ", /* 15 */
+    "  1  Loud       q  Quit game       ",      /* 10 */
+    "  0  Quiet      !  Look at map     ",      /* 11 */
+    "  S  Save game  R  Restore Game    ",      /* 12 */
+    "  ?  Help mode  @  Center screen   ",      /* 13 */
+    "  ~  Jump level #  Switch mode     ",      /* 14 */
+    " (no bonus)     W,^L Redraw screen ",      /* 15 */
 #else
-"  q  Quit game  !  Look at map     ", /* 10 */
-"  S  Save game  R  Restore Game    ", /* 11 */
-"  ?  Help mode  @  Center screen   ", /* 12 */
-"  #  Other mode W,^L Redraw screen ", /* 13 */
-"  ~  Jump level (no bonus recieved)", /* 14 */
-"                                   ", /* 15 */
+    "  q  Quit game  !  Look at map     ",      /* 10 */
+    "  S  Save game  R  Restore Game    ",      /* 11 */
+    "  ?  Help mode  @  Center screen   ",      /* 12 */
+    "  #  Other mode W,^L Redraw screen ",      /* 13 */
+    "  ~  Jump level (no bonus recieved)",      /* 14 */
+    "                                   ",      /* 15 */
 #endif
 
-"This is you:  You are a spider.    ", /* 0 */
-"      o       (At least, that's    ", /* 1 */
-"     <|>      what you look like)  ", /* 2 */
-"                                   ", /* 3 */
-"The other items you will find are: ", /* 4 */
-"                                   ", /* 5 */
-"  ###     -=- Solid Rock. The first", /* 6 */
-"  ### and =-= cannot be blown up.  ", /* 7 */
-"                                   ", /* 8 */
-"  <O>   Time capsule (5 points,    ", /* 9 */
-"        +250 extra moves)          ", /* 10 */
-"   .                               ", /* 11 */
-"  . .   Passable earth (one point) ", /* 12 */
-"                                   ", /* 13 */
-" (*)   Teleport  (50 points for    ", /* 14 */
-" (*)              using it)        ", /* 15 */
+    "This is you:  You are a spider.    ",      /* 0 */
+    "      o       (At least, that's    ",      /* 1 */
+    "     <|>      what you look like)  ",      /* 2 */
+    "                                   ",      /* 3 */
+    "The other items you will find are: ",      /* 4 */
+    "                                   ",      /* 5 */
+    "  ###     -=- Solid Rock. The first",      /* 6 */
+    "  ### and =-= cannot be blown up.  ",      /* 7 */
+    "                                   ",      /* 8 */
+    "  <O>   Time capsule (5 points,    ",      /* 9 */
+    "        +250 extra moves)          ",      /* 10 */
+    "   .                               ",      /* 11 */
+    "  . .   Passable earth (one point) ",      /* 12 */
+    "                                   ",      /* 13 */
+    " (*)   Teleport  (50 points for    ",      /* 14 */
+    " (*)              using it)        ",      /* 15 */
 
-"  /^\\   Boulder (falls down, other ", /* 0 */
-"  \\_/   boulders and arrows fall   ", /* 1 */
-"        off of it)                 ", /* 2 */
-"                                   ", /* 3 */
-"  <--     -->  Arrows              ", /* 4 */
-"  <-- and -->  (run left and right)", /* 5 */
-"                                   ", /* 6 */
-"  TTT   Cage - holds baby monsters ", /* 7 */
-"  III   and changes into diamonds  ", /* 8 */
-"                                   ", /* 9 */
-"  /$\\    (10 points)               ", /* 0 */
-"  \\$/    Money  (collect it)       ", /* 1 */
-"                                   ", /* 2 */
-"  -o-  Baby monster (kills you)    ", /* 3 */
-"  /*\\                              ", /* 4 */
-"                                   ", /* 5 */
+    "  /^\\   Boulder (falls down, other ",     /* 0 */
+    "  \\_/   boulders and arrows fall   ",     /* 1 */
+    "        off of it)                 ",      /* 2 */
+    "                                   ",      /* 3 */
+    "  <--     -->  Arrows              ",      /* 4 */
+    "  <-- and -->  (run left and right)",      /* 5 */
+    "                                   ",      /* 6 */
+    "  TTT   Cage - holds baby monsters ",      /* 7 */
+    "  III   and changes into diamonds  ",      /* 8 */
+    "                                   ",      /* 9 */
+    "  /$\\    (10 points)               ",     /* 0 */
+    "  \\$/    Money  (collect it)       ",     /* 1 */
+    "                                   ",      /* 2 */
+    "  -o-  Baby monster (kills you)    ",      /* 3 */
+    "  /*\\                              ",     /* 4 */
+    "                                   ",      /* 5 */
 
-"When a baby monster hits a cage it ", /* 0 */
-"is captured and you get 50 points. ", /* 1 */
-"The cage also becomes a diamond.   ", /* 2 */
-"                                   ", /* 3 */
-"  I   Instant annihilation         ", /* 4 */
-"  o                                ", /* 5 */
-"                                   ", /* 6 */
-" \\_       _/   Slopes (boulders    ", /* 7 */
-"   \\ and /     and etc slide off)  ", /* 8 */
-"                                   ", /* 9 */
-" }o{  Monster  (eats you up whole. ", /* 0 */
-" /^\\  Yum Yum yum..) (100 points)  ", /* 1 */
-"      (kill with a rock or arrow)  ", /* 2 */
-"                                   ", /* 3 */
-" Way  Exit -- Must collect all the ", /* 4 */
-" out  treasure first. (250 bonus)  ", /* 5 */
+    "When a baby monster hits a cage it ",      /* 0 */
+    "is captured and you get 50 points. ",      /* 1 */
+    "The cage also becomes a diamond.   ",      /* 2 */
+    "                                   ",      /* 3 */
+    "  I   Instant annihilation         ",      /* 4 */
+    "  o                                ",      /* 5 */
+    "                                   ",      /* 6 */
+    " \\_       _/   Slopes (boulders    ",     /* 7 */
+    "   \\ and /     and etc slide off)  ",     /* 8 */
+    "                                   ",      /* 9 */
+    " }o{  Monster  (eats you up whole. ",      /* 0 */
+    " /^\\  Yum Yum yum..) (100 points)  ",     /* 1 */
+    "      (kill with a rock or arrow)  ",      /* 2 */
+    "                                   ",      /* 3 */
+    " Way  Exit -- Must collect all the ",      /* 4 */
+    " out  treasure first. (250 bonus)  ",      /* 5 */
 
-" /~\\  Balloon -- rises, and is     ", /* 0 */
-" \\_X   popped by arrows. It does   ", /* 1 */
-"        *not* kill you.            ", /* 2 */
-"                                   ", /* 3*/
-" OOO  Unrecognised symbol in map.  ", /* 4*/
-" OOO  This is probably a **bug** ! ", /* 5*/
-"                                   ", /* 6 */
-" \\|/  'Thingy' - can be pushed in  ", /* 7 */
-" /|\\   any direction by you or by  ", /* 8 */
-"        arrows/boulders/balloons   ",  /* 9 */
-"                                   ",  /* 0 */
-" _|_  Another wall character, for  ",  /* 1 */
-" _|_  more variety to the game     ",  /* 2 */
-"                                   ",  /* 3 */
-" /\\*  Bomb - explodes when hit by  ",  /* 4 */
-" \\/  arrow/boulder. Destroys area. ",  /* 5 */
+    " /~\\  Balloon -- rises, and is     ",     /* 0 */
+    " \\_X   popped by arrows. It does   ",     /* 1 */
+    "        *not* kill you.            ",      /* 2 */
+    "                                   ",      /* 3 */
+    " OOO  Unrecognised symbol in map.  ",      /* 4 */
+    " OOO  This is probably a **bug** ! ",      /* 5 */
+    "                                   ",      /* 6 */
+    " \\|/  'Thingy' - can be pushed in  ",     /* 7 */
+    " /|\\   any direction by you or by  ",     /* 8 */
+    "        arrows/boulders/balloons   ",      /* 9 */
+    "                                   ",      /* 0 */
+    " _|_  Another wall character, for  ",      /* 1 */
+    " _|_  more variety to the game     ",      /* 2 */
+    "                                   ",      /* 3 */
+    " /\\*  Bomb - explodes when hit by  ",     /* 4 */
+    " \\/  arrow/boulder. Destroys area. ",     /* 5 */
 
-"  SCORING:                         ",  /* 0 */
-"    Score 1 for earth, 10 for money",  /* 1 */
-" 5 for capsule, 20 for teleporting ", /* 2 */
-" 100 for killing monster, 20 for   ", /* 3 */
-" catching baby monster, 250 for    ", /* 4 */
-" escaping with all the money.      ", /* 5 */
-"                                   ", /* 6 */
-"                                   ", /* 7 */
-" ENVIRONMENT VARIABLES:            ", /* 8 */
-"                                   ", /* 9 */
-"   NEWNAME,NAME : Checked in that  ", /* 0 */
-"       order for the hiscore table ", /* 1 */
-"   NEWKEYS : Redefine movement keys", /* 2 */
-"       eg- 'hlkj' for default      ", /* 3 */
-"   SAVENAME : File used for saved  ", /* 4 */
-"       games.                      ", /* 5 */
+    "  SCORING:                         ",      /* 0 */
+    "    Score 1 for earth, 10 for money",      /* 1 */
+    " 5 for capsule, 20 for teleporting ",      /* 2 */
+    " 100 for killing monster, 20 for   ",      /* 3 */
+    " catching baby monster, 250 for    ",      /* 4 */
+    " escaping with all the money.      ",      /* 5 */
+    "                                   ",      /* 6 */
+    "                                   ",      /* 7 */
+    " ENVIRONMENT VARIABLES:            ",      /* 8 */
+    "                                   ",      /* 9 */
+    "   NEWNAME,NAME : Checked in that  ",      /* 0 */
+    "       order for the hiscore table ",      /* 1 */
+    "   NEWKEYS : Redefine movement keys",      /* 2 */
+    "       eg- 'hlkj' for default      ",      /* 3 */
+    "   SAVENAME : File used for saved  ",      /* 4 */
+    "       games.                      ",      /* 5 */
 
-"  Options:                         ",
-"                                   ",
-"  -r (file) : record moves to file ",
-"  -t (file) : test screen          ",
-"  -e (file) : edit screen          ",
-"  -c        : show credits file    ",
-"  -v        : show version  number ",
-"  -m        : edit hiscore file    ",
-"  -s        : show hiscore file    ",
-"  -k string : define keys          ",
-"  -f        : full-screen mode     ",
+    "  Options:                         ",
+    "                                   ",
+    "  -r (file) : record moves to file ",
+    "  -t (file) : test screen          ",
+    "  -e (file) : edit screen          ",
+    "  -c        : show credits file    ",
+    "  -v        : show version  number ",
+    "  -m        : edit hiscore file    ",
+    "  -s        : show hiscore file    ",
+    "  -k string : define keys          ",
+    "  -f        : full-screen mode     ",
 #ifdef NOISY
-"  -1 and -0 : start wil bell on/off",
+    "  -1 and -0 : start wil bell on/off",
 #else
-"                                   ",
+    "                                   ",
 #endif
-"                                   ",
-" *** Thanks to everyone who helped ",
-"     with the beta testing!        ",
-"                                   ",
-NULL };
+    "                                   ",
+    " *** Thanks to everyone who helped ",
+    "     with the beta testing!        ",
+    "                                   ",
+    NULL
+};
 
 char *edhelp[] = {
-" The Keys:                         ",
-"                                   ",
-"   n: play game with full screen   ",
-"   p: play with normal screen      ",
-"   c: change screen name           ",
-"   m: change moves allowance       ",
-"                                   ",
-"   \": next character is literal    ",
-"   L: check screen legality        ",
-"   q: quit, saving screen          ",
-"   x: exit, do not save screen     ",
-"   CTRL-R: read moves memory       ",
-"   CTRL-W: write moves memory      ",
-"   CTRL-L: redraw screen           ",
-"   CTRL-G: read screen file  (get) ",
-"   CTRL-P: write screen file (put) ",
+    " The Keys:                         ",
+    "                                   ",
+    "   n: play game with full screen   ",
+    "   p: play with normal screen      ",
+    "   c: change screen name           ",
+    "   m: change moves allowance       ",
+    "                                   ",
+    "   \": next character is literal    ",
+    "   L: check screen legality        ",
+    "   q: quit, saving screen          ",
+    "   x: exit, do not save screen     ",
+    "   CTRL-R: read moves memory       ",
+    "   CTRL-W: write moves memory      ",
+    "   CTRL-L: redraw screen           ",
+    "   CTRL-G: read screen file  (get) ",
+    "   CTRL-P: write screen file (put) ",
 
-"  THE WANDERER SCREEN EDITOR HELP  ",
-"  -------------------------------  ",
-"                                   ",
-"  The editor has a number of       ",
-" special features. The main ones   ",
-" are summarised at the bottom of   ",
-" the screen, but there are also    ",
-" a few more advanced features.     ",
-"  These are described on the next  ",
-" page.                             ",
-"                                   ",
-"  When playing a screen, you will  ",
-" not die (usually) but will instead",
-" be given the option of continuing ",
-" the game from where you died.     ",
-"                                   ",
+    "  THE WANDERER SCREEN EDITOR HELP  ",
+    "  -------------------------------  ",
+    "                                   ",
+    "  The editor has a number of       ",
+    " special features. The main ones   ",
+    " are summarised at the bottom of   ",
+    " the screen, but there are also    ",
+    " a few more advanced features.     ",
+    "  These are described on the next  ",
+    " page.                             ",
+    "                                   ",
+    "  When playing a screen, you will  ",
+    " not die (usually) but will instead",
+    " be given the option of continuing ",
+    " the game from where you died.     ",
+    "                                   ",
 
-" L: check legality                 ",
-"                                   ",
-"  The legality checker can also be ",
-" called via the -t option. Any     ",
-" minor errors - ie ones the game   ",
-" can survive - are prefixed with   ",
-" '+++' and any major (fatal) errors",
-" are prefixed '***'. A screen      ",
-" should have no errors.            ",
-"                                   ",
-"                                   ",
-" CTRL-W, CTRL-R: moves memory      ",
-"                                   ",
-"  When playing the game you have   ",
-" the ability to record your moves, ",
-" and to play them back again.      ",
+    " L: check legality                 ",
+    "                                   ",
+    "  The legality checker can also be ",
+    " called via the -t option. Any     ",
+    " minor errors - ie ones the game   ",
+    " can survive - are prefixed with   ",
+    " '+++' and any major (fatal) errors",
+    " are prefixed '***'. A screen      ",
+    " should have no errors.            ",
+    "                                   ",
+    "                                   ",
+    " CTRL-W, CTRL-R: moves memory      ",
+    "                                   ",
+    "  When playing the game you have   ",
+    " the ability to record your moves, ",
+    " and to play them back again.      ",
 
-"  You can save this memory to a    ",
-" text file, or load from a suitable",
-" file, using these keys. When      ",
-" playing the game, press '(' to    ",
-" start recording and ')' to end.   ",
-" Also, pressing '+' will introduce ",
-" a checkpoint.                     ",
-"  Press '*' to playback the moves  ",
-" from the beginning. The playback  ",
-" will stop at the end, or at a     ",
-" checkpoint. Press '-' to continue ",
-" from a checkpoint.                ",
-"  Pressing '&' will start recording",
-" from the current position - this  ",
-" will either extend the memory,    ",
-" or, if used when playback has     ",
+    "  You can save this memory to a    ",
+    " text file, or load from a suitable",
+    " file, using these keys. When      ",
+    " playing the game, press '(' to    ",
+    " start recording and ')' to end.   ",
+    " Also, pressing '+' will introduce ",
+    " a checkpoint.                     ",
+    "  Press '*' to playback the moves  ",
+    " from the beginning. The playback  ",
+    " will stop at the end, or at a     ",
+    " checkpoint. Press '-' to continue ",
+    " from a checkpoint.                ",
+    "  Pressing '&' will start recording",
+    " from the current position - this  ",
+    " will either extend the memory,    ",
+    " or, if used when playback has     ",
 
-" stopped at a checkpoint, it will  ",
-" overwrite any following data.     ",
-"                                   ",
-"  The memory is a maximum of 1024  ",
-" bytes (this can be changed in the ",
-" wand_head.h file).                ",
-"                                   ",
-"                                   ",
-" CTRL-G and CTRL-P: get and put    ",
-"                                   ",
-"  These will read and write the    ",
-" screen data. As with the memory   ",
-" functions, a file name is prompted",
-" for. Pressing return will use the ",
-" default provided.                 ",
-"                                   ",
+    " stopped at a checkpoint, it will  ",
+    " overwrite any following data.     ",
+    "                                   ",
+    "  The memory is a maximum of 1024  ",
+    " bytes (this can be changed in the ",
+    " wand_head.h file).                ",
+    "                                   ",
+    "                                   ",
+    " CTRL-G and CTRL-P: get and put    ",
+    "                                   ",
+    "  These will read and write the    ",
+    " screen data. As with the memory   ",
+    " functions, a file name is prompted",
+    " for. Pressing return will use the ",
+    " default provided.                 ",
+    "                                   ",
 
-NULL };
+    NULL
+};
 
 /**********************************************
 *               function helpme               *
 ***********************************************/
-void helpme(int htype)   /* routine to show help menu. */
+void helpme(int htype)          /* routine to show help menu. */
                          /* htype 0 == editor          */
 {
-         int i = 0, i2 = 0;   /* loop counters      */
-         char *ptr;           /* pointer in array.. */
-         char ch;
-         char **helplist;
+    int i = 0, i2 = 0;          /* loop counters      */
+    char *ptr;                  /* pointer in array.. */
+    char ch;
+    char **helplist;
 
-         if( htype )
-             helplist = help;
-         else
-             helplist = edhelp;
+    if (htype)
+        helplist = help;
+    else
+        helplist = edhelp;
 
-         /* clear board - fullscreen mode is too big to overlay */
-        for(i = 0; i < 18; i++)
+    /* clear board - fullscreen mode is too big to overlay */
+    for (i = 0; i < 18; i++)
+    {
+        move(i, 0);
+        addstr("                                           ");
+    }
+
+    while (helplist[i2])        /* times to show loop. */
+    {
+        for (i = 0; i < 16; i++)        /* show one menu. */
         {
-                  move(i,0);
-                  addstr("                                           ");
-         }
-
-         while( helplist[i2] )  /* times to show loop. */
-         {
-                  for(i = 0; i < 16; i++)         /* show one menu. */
-                  {
-                           ptr = helplist[i2++];
-                           move(i,0);  /* move to start of line. */
-                           addstr(ptr);
-                  }
-                  move(i,0);  /* move to start of line. */
+            ptr = helplist[i2++];
+            move(i, 0);         /* move to start of line. */
+            addstr(ptr);
+        }
+        move(i, 0);             /* move to start of line. */
 #ifdef TVI
-                  addstr(TVI);
+        addstr(TVI);
 #else
-                  standout();
+        standout();
 #endif
-                  if( helplist[i2] )
-                      addstr("Press any key to continue, <q> to exit");
-                 else
-                      addstr("End of help. Press any key to exit    ");
+        if (helplist[i2])
+            addstr("Press any key to continue, <q> to exit");
+        else
+            addstr("End of help. Press any key to exit    ");
 #ifdef NOTVI
-                  addstr(NOTVI);
+        addstr(NOTVI);
 #else
-                  standend();
+        standend();
 #endif
-                  refresh();               /* show on screen. */
-                  ch = (char) getchar();   /* just for now, get anything. */
-                  if(ch == 'q')            /* if return or what ever.. */
-                           break;          /* exit routine now. */
-         }
-         move(i,0);  /* move to start of line. */
-         addstr("                                        ");
+        refresh();              /* show on screen. */
+        ch = (char) getchar();  /* just for now, get anything. */
+        if (ch == 'q')          /* if return or what ever.. */
+            break;              /* exit routine now. */
+    }
+    move(i, 0);                 /* move to start of line. */
+    addstr("                                        ");
 }

--- a/help.c
+++ b/help.c
@@ -248,7 +248,7 @@ void helpme(int htype)          /* routine to show help menu. */
     for (i = 0; i < 18; i++)
     {
         move(i, 0);
-        addstr("                                           ");
+        printw("%43s", "");
     }
 
     while (helplist[i2])        /* times to show loop. */
@@ -280,5 +280,5 @@ void helpme(int htype)          /* routine to show help menu. */
             break;              /* exit routine now. */
     }
     move(i, 0);                 /* move to start of line. */
-    addstr("                                        ");
+    printw("%40s", "");
 }

--- a/icon.c
+++ b/icon.c
@@ -7,115 +7,114 @@
 /********************************************************
 *                     draw_symbol                       *
 *********************************************************/
-void draw_symbol(int x, int y, char ch)     /* this is where the pretty graphics are   */
+void draw_symbol(int x, int y, char ch) /* this is where the pretty graphics are   */
                                             /* all defined - change them if you want.. */
 {
-    char icon[2][4],
-         (*iconrow)[4] = icon;
-    switch(ch)
+    char icon[2][4], (*iconrow)[4] = icon;
+    switch (ch)
     {
-    case ' ':                    /*  space  */
-        strcpy(*iconrow++,"   ");
-        strcpy(*iconrow,  "   ");
+    case ' ':                  /*  space  */
+        strcpy(*iconrow++, "   ");
+        strcpy(*iconrow, "   ");
         break;
-    case '#':                   /*  rock  */
-        strcpy(*iconrow++,"###");
-        strcpy(*iconrow,  "###");
+    case '#':                  /*  rock  */
+        strcpy(*iconrow++, "###");
+        strcpy(*iconrow, "###");
         break;
-    case '<':                   /*  arrows  */
-        strcpy(*iconrow++,"<--");
-        strcpy(*iconrow,  "<--");
+    case '<':                  /*  arrows  */
+        strcpy(*iconrow++, "<--");
+        strcpy(*iconrow, "<--");
         break;
     case '>':
-        strcpy(*iconrow++,"-->");
-        strcpy(*iconrow,  "-->");
+        strcpy(*iconrow++, "-->");
+        strcpy(*iconrow, "-->");
         break;
-    case 'O':                    /* boulder  */
-        strcpy(*iconrow++,"/^\\");
-        strcpy(*iconrow,  "\\_/");
+    case 'O':                  /* boulder  */
+        strcpy(*iconrow++, "/^\\");
+        strcpy(*iconrow, "\\_/");
         break;
-    case ':':                    /*  earth  */
-        strcpy(*iconrow++,". .");
-        strcpy(*iconrow,  " . ");
+    case ':':                  /*  earth  */
+        strcpy(*iconrow++, ". .");
+        strcpy(*iconrow, " . ");
         break;
-    case '/':                    /*  slopes */
-        strcpy(*iconrow++," _/");
-        strcpy(*iconrow,  "/  ");
+    case '/':                  /*  slopes */
+        strcpy(*iconrow++, " _/");
+        strcpy(*iconrow, "/  ");
         break;
     case '\\':
-        strcpy(*iconrow++,"\\_ ");
-        strcpy(*iconrow,  "  \\");
+        strcpy(*iconrow++, "\\_ ");
+        strcpy(*iconrow, "  \\");
         break;
-    case '*':                     /*  diamond  */
-        strcpy(*iconrow++,"/$\\");
-        strcpy(*iconrow,  "\\$/");
+    case '*':                  /*  diamond  */
+        strcpy(*iconrow++, "/$\\");
+        strcpy(*iconrow, "\\$/");
         break;
-    case '=':                     /*  rock  */
-        strcpy(*iconrow++,"=-=");
-        strcpy(*iconrow,  "-=-");
+    case '=':                  /*  rock  */
+        strcpy(*iconrow++, "=-=");
+        strcpy(*iconrow, "-=-");
         break;
-    case '@':                     /*  YOU!!! */
-        strcpy(*iconrow++," o ");
-        strcpy(*iconrow,  "<|>");
+    case '@':                  /*  YOU!!! */
+        strcpy(*iconrow++, " o ");
+        strcpy(*iconrow, "<|>");
         break;
-    case '~':                     /* pushable thingy */
-         strcpy(*iconrow++,"\\|/");
-         strcpy(*iconrow  ,"/|\\");
-         break;
+    case '~':                  /* pushable thingy */
+        strcpy(*iconrow++, "\\|/");
+        strcpy(*iconrow, "/|\\");
+        break;
     case 't':
-    case 'T':                    /*  teleport  */
-        strcpy(*iconrow++,"(*)");
-        strcpy(*iconrow,  "(*)");
+    case 'T':                  /*  teleport  */
+        strcpy(*iconrow++, "(*)");
+        strcpy(*iconrow, "(*)");
         break;
-    case 'X':                    /*  exits  */
-        strcpy(*iconrow++,"Way");
-        strcpy(*iconrow,  "Out");
+    case 'X':                  /*  exits  */
+        strcpy(*iconrow++, "Way");
+        strcpy(*iconrow, "Out");
         break;
-    case '!':                    /*  landmine  */
-        strcpy(*iconrow++," I ");
-        strcpy(*iconrow,  " o ");
+    case '!':                  /*  landmine  */
+        strcpy(*iconrow++, " I ");
+        strcpy(*iconrow, " o ");
         break;
-    case 'M':                     /* big monster  */
-        strcpy(*iconrow++,"}o{");
-        strcpy(*iconrow,  "/^\\");
+    case 'M':                  /* big monster  */
+        strcpy(*iconrow++, "}o{");
+        strcpy(*iconrow, "/^\\");
         break;
-    case 'S':                     /* baby monster */
-        strcpy(*iconrow++,"-o-");
-        strcpy(*iconrow,  "/*\\");
+    case 'S':                  /* baby monster */
+        strcpy(*iconrow++, "-o-");
+        strcpy(*iconrow, "/*\\");
         break;
-    case '^':                      /* balloon */
-        strcpy(*iconrow++,"/~\\");
-        strcpy(*iconrow,  "\\_X");
+    case '^':                  /* balloon */
+        strcpy(*iconrow++, "/~\\");
+        strcpy(*iconrow, "\\_X");
         break;
-    case 'C':                      /* time capsule */
-        strcpy(*iconrow++,"   ");
-        strcpy(*iconrow,  "<O>");
+    case 'C':                  /* time capsule */
+        strcpy(*iconrow++, "   ");
+        strcpy(*iconrow, "<O>");
         break;
-    case '+':                      /* cage */
-        strcpy(*iconrow++,"TTT");
-        strcpy(*iconrow,  "III");
+    case '+':                  /* cage */
+        strcpy(*iconrow++, "TTT");
+        strcpy(*iconrow, "III");
         break;
-    case '_':                      /* more wall characters */
-        strcpy(*iconrow++,"_|_");
-         strcpy(*iconrow  ,"_|_");
-         break;
-    case 'B':                      /* the bomb */
-         strcpy(*iconrow++,"/\\*");
-         strcpy(*iconrow  ,"\\/ ");
-          break;
-    case '%':                      /* the explosion */
-         strcpy(*iconrow++,"Ba\\");
-         strcpy(*iconrow  ,"\\ng");
-          break;
-    default:                       /* this is what it uses if it doesnt */
-                                   /* recognise the character  */
-        strcpy(*iconrow++,"OoO");
-        strcpy(*iconrow,  "oOo");
+    case '_':                  /* more wall characters */
+        strcpy(*iconrow++, "_|_");
+        strcpy(*iconrow, "_|_");
+        break;
+    case 'B':                  /* the bomb */
+        strcpy(*iconrow++, "/\\*");
+        strcpy(*iconrow, "\\/ ");
+        break;
+    case '%':                  /* the explosion */
+        strcpy(*iconrow++, "Ba\\");
+        strcpy(*iconrow, "\\ng");
+        break;
+    default:                   /* this is what it uses if it doesnt */
+        /* recognise the character  */
+        strcpy(*iconrow++, "OoO");
+        strcpy(*iconrow, "oOo");
         break;
     };
-    move(y+1,x+1);
+    move(y + 1, x + 1);
     iconrow--;
     addstr(*iconrow++);
-    move(y+2,x+1);
+    move(y + 2, x + 1);
     addstr(*iconrow);
 }

--- a/jump.c
+++ b/jump.c
@@ -44,7 +44,6 @@ int scrn_passwd(int num, char *passwd)  /* reads password num into passwd */
 void showpass(int num)
 {
     char correct[20];
-    char buffer[100];
     if (no_passwords)
         return;
     if (!debug_disp)
@@ -53,21 +52,17 @@ void showpass(int num)
         move(20, 0);
     if (!scrn_passwd(num, correct))
         return;
-    sprintf(buffer,
-            "The password to jump to level %d ( using ~ ) is : %s        \n",
-            (num + 1), correct);
-    addstr(buffer);
-    addstr
-        ("PRESS ANY KEY TO REMOVE IT AND CONTINUE                          \n");
+    printw("The password to jump to level %d ( using ~ ) is : %s        \n",
+           (num + 1), correct);
+    printw("%-65s\n", "PRESS ANY KEY TO REMOVE IT AND CONTINUE");
     refresh();
     getch();
     if (!debug_disp)
         move(18, 0);
     else
         move(20, 0);
-    addstr
-        ("                                                                        \n");
-    addstr("                                              ");
+    printw("%72s\n", "");
+    printw("%46s", "");
     if (!debug_disp)
         move(18, 0);
     else
@@ -80,7 +75,7 @@ void showpass(int num)
 ***********************************************************/
 int jumpscreen(int num)
 {
-    char word[20], buffer[100], correct[20];
+    char word[20], correct[20];
     int index = 0;
     int scrn;
     struct timespec t;
@@ -100,7 +95,7 @@ int jumpscreen(int num)
                 move(16, 0);
             else
                 move(18, 0);
-            addstr("                                                ");
+            printw("*48s", "");
             return scrn;
         }
         if (!debug_disp)
@@ -128,7 +123,7 @@ int jumpscreen(int num)
         move(16, 0);
     else
         move(18, 0);
-    addstr("Validating...                                             \n");
+    printw("%-58s\n", "Validating...");
     refresh();
 
     if (strcmp(word, MASTERPASSWORD) == 0)
@@ -141,30 +136,25 @@ int jumpscreen(int num)
         refresh();
         num = getnum();
         (void) scrn_passwd(num - 1, correct);
-        sprintf(buffer,
-                "Certainly master, but the correct word is %s.       \n",
-                correct);
         if (!debug_disp)
             move(16, 0);
         else
             move(18, 0);
-        addstr(buffer);
-        addstr
-            ("PRESS ANY KEY TO REMOVE IT AND CONTINUE                          \n");
+        printw("Certainly master, but the correct word is %s.       \n",
+               correct);
+        printw("%-65s\n", "PRESS ANY KEY TO REMOVE IT AND CONTINUE");
         refresh();
         getchar();
         if (!debug_disp)
             move(16, 0);
         else
             move(18, 0);
-        addstr
-            ("                                                             ");
+        printw("%61s", "");
         if (!debug_disp)
             move(17, 0);
         else
             move(19, 0);
-        addstr
-            ("                                                             ");
+        printw("%61s", "");
         if (!debug_disp)
             move(16, 0);
         else
@@ -183,8 +173,8 @@ int jumpscreen(int num)
                 move(16, 0);
             else
                 move(18, 0);
-            addstr
-                ("Password Validated..... Jumping to desired screen.        ");
+            printw("%-58s",
+                   "Password Validated..... Jumping to desired screen.");
             refresh();
             return ++scrn;
         }
@@ -194,7 +184,7 @@ int jumpscreen(int num)
         move(16, 0);
     else
         move(18, 0);
-    addstr("PASSWORD NOT RECOGNISED!                    ");
+    printw("%-44s", "PASSWORD NOT RECOGNISED!");
     refresh();
     t.tv_sec = 0;
     t.tv_nsec = 750000000;
@@ -203,7 +193,7 @@ int jumpscreen(int num)
         move(16, 0);
     else
         move(18, 0);
-    addstr("                                                          ");
+    printw("%61s", "");
 
     return num;
 }

--- a/jump.c
+++ b/jump.c
@@ -16,25 +16,26 @@ extern int maxscreens;
 *                   function scrn_passwd                    *
 *              reads password num into passwd               *
 *************************************************************/
-int scrn_passwd(int num, char *passwd)    /* reads password num into passwd */
+int scrn_passwd(int num, char *passwd)  /* reads password num into passwd */
 {
-        long position;
-        FILE *fp;
+    long position;
+    FILE *fp;
 
-        position = PASSWD;
-        while(position > 200000)
-                position -= 200000;
-        if((fp = fopen(DICTIONARY,"r")) == NULL)
-                return 0;
-        fseek(fp,position,ftell(fp));
-        while(fgetc(fp) != '\n');
-        if (fscanf(fp,"%s\n",passwd) == EOF && errno != 0) {
-            fprintf(stderr, "fscanf error\n");
-            exit(EXIT_FAILURE);
-        }
-        /* read a word into passwd */
-        fclose(fp);
-        return (1);
+    position = PASSWD;
+    while (position > 200000)
+        position -= 200000;
+    if ((fp = fopen(DICTIONARY, "r")) == NULL)
+        return 0;
+    fseek(fp, position, ftell(fp));
+    while (fgetc(fp) != '\n');
+    if (fscanf(fp, "%s\n", passwd) == EOF && errno != 0)
+    {
+        fprintf(stderr, "fscanf error\n");
+        exit(EXIT_FAILURE);
+    }
+    /* read a word into passwd */
+    fclose(fp);
+    return (1);
 }
 
 /*******************************************************
@@ -44,29 +45,33 @@ void showpass(int num)
 {
     char correct[20];
     char buffer[100];
-    if(no_passwords)
+    if (no_passwords)
         return;
-    if(!debug_disp)
-        move(18,0);
+    if (!debug_disp)
+        move(18, 0);
     else
-        move(20,0);
-    if(!scrn_passwd(num,correct))
+        move(20, 0);
+    if (!scrn_passwd(num, correct))
         return;
-    sprintf(buffer,"The password to jump to level %d ( using ~ ) is : %s        \n",(num+1),correct);
+    sprintf(buffer,
+            "The password to jump to level %d ( using ~ ) is : %s        \n",
+            (num + 1), correct);
     addstr(buffer);
-    addstr("PRESS ANY KEY TO REMOVE IT AND CONTINUE                          \n");
+    addstr
+        ("PRESS ANY KEY TO REMOVE IT AND CONTINUE                          \n");
     refresh();
     getch();
-    if(!debug_disp)
-        move(18,0);
+    if (!debug_disp)
+        move(18, 0);
     else
-        move(20,0);
-    addstr("                                                                        \n");
+        move(20, 0);
+    addstr
+        ("                                                                        \n");
     addstr("                                              ");
-    if(!debug_disp)
-        move(18,0);
+    if (!debug_disp)
+        move(18, 0);
     else
-        move(20,0);
+        move(20, 0);
     refresh();
 }
 
@@ -75,122 +80,129 @@ void showpass(int num)
 ***********************************************************/
 int jumpscreen(int num)
 {
-    char word[20],
-         buffer[100],
-         correct[20];
-    int index=0;
+    char word[20], buffer[100], correct[20];
+    int index = 0;
     int scrn;
     struct timespec t;
 
-    if(no_passwords == 1) {
-        if(!debug_disp)
-            move(16,0);
+    if (no_passwords == 1)
+    {
+        if (!debug_disp)
+            move(16, 0);
         else
-            move(18,0);
+            move(18, 0);
         addstr("Enter number of desired level.\n");
         refresh();
         scrn = getnum();
-        if(scrn > num) {
-            if(!debug_disp)
-                move(16,0);
+        if (scrn > num)
+        {
+            if (!debug_disp)
+                move(16, 0);
             else
-                move(18,0);
+                move(18, 0);
             addstr("                                                ");
             return scrn;
-            }
-        if(!debug_disp)
-            move(16,0);
+        }
+        if (!debug_disp)
+            move(16, 0);
         else
-            move(18,0);
+            move(18, 0);
         addstr("No way, Jose! Back-jumping is prohibited!");
         refresh();
         return num;
     }
 
-    if(!debug_disp)
-        move(16,0);
+    if (!debug_disp)
+        move(16, 0);
     else
-        move(18,0);
+        move(18, 0);
     addstr("Please enter password of screen to jump to:");
     refresh();
-    while(((word[index++] = getch()) != '\n')&&(index < 19))
+    while (((word[index++] = getch()) != '\n') && (index < 19))
     {
         addch('*');
         refresh();
     }
-    word[--index]='\0';
-    if(!debug_disp)
-        move(16,0);
+    word[--index] = '\0';
+    if (!debug_disp)
+        move(16, 0);
     else
-        move(18,0);
+        move(18, 0);
     addstr("Validating...                                             \n");
     refresh();
 
-    if(strcmp(word,MASTERPASSWORD) == 0)
+    if (strcmp(word, MASTERPASSWORD) == 0)
     {
-        if(!debug_disp)
-            move(16,0);
+        if (!debug_disp)
+            move(16, 0);
         else
-            move(18,0);
+            move(18, 0);
         addstr("Enter number of desired level.");
         refresh();
         num = getnum();
-        (void) scrn_passwd(num-1,correct);
-        sprintf(buffer,"Certainly master, but the correct word is %s.       \n",correct);
-        if(!debug_disp)
-            move(16,0);
+        (void) scrn_passwd(num - 1, correct);
+        sprintf(buffer,
+                "Certainly master, but the correct word is %s.       \n",
+                correct);
+        if (!debug_disp)
+            move(16, 0);
         else
-            move(18,0);
+            move(18, 0);
         addstr(buffer);
-        addstr("PRESS ANY KEY TO REMOVE IT AND CONTINUE                          \n");
+        addstr
+            ("PRESS ANY KEY TO REMOVE IT AND CONTINUE                          \n");
         refresh();
         getchar();
-        if(!debug_disp)
-            move(16,0);
+        if (!debug_disp)
+            move(16, 0);
         else
-            move(18,0);
-        addstr("                                                             ");
-        if(!debug_disp)
-            move(17,0);
+            move(18, 0);
+        addstr
+            ("                                                             ");
+        if (!debug_disp)
+            move(17, 0);
         else
-            move(19,0);
-        addstr("                                                             ");
-        if(!debug_disp)
-            move(16,0);
+            move(19, 0);
+        addstr
+            ("                                                             ");
+        if (!debug_disp)
+            move(16, 0);
         else
-            move(18,0);
+            move(18, 0);
         refresh();
         return num;
     }
 
-    for(scrn = num;scrn < maxscreens;scrn++) {
-        if(!scrn_passwd(scrn,correct))
+    for (scrn = num; scrn < maxscreens; scrn++)
+    {
+        if (!scrn_passwd(scrn, correct))
             break;
-        if(strcmp(correct,word) == 0)
+        if (strcmp(correct, word) == 0)
         {
-            if(!debug_disp)
-                move(16,0);
+            if (!debug_disp)
+                move(16, 0);
             else
-                move(18,0);
-            addstr("Password Validated..... Jumping to desired screen.        ");
+                move(18, 0);
+            addstr
+                ("Password Validated..... Jumping to desired screen.        ");
             refresh();
             return ++scrn;
         }
     }
 
-    if(!debug_disp)
-        move(16,0);
+    if (!debug_disp)
+        move(16, 0);
     else
-        move(18,0);
+        move(18, 0);
     addstr("PASSWORD NOT RECOGNISED!                    ");
     refresh();
     t.tv_sec = 0;
     t.tv_nsec = 750000000;
     nanosleep(&t, NULL);
-    if(!debug_disp)
-        move(16,0);
+    if (!debug_disp)
+        move(16, 0);
     else
-        move(18,0);
+        move(18, 0);
     addstr("                                                          ");
 
     return num;
@@ -204,9 +216,8 @@ int getnum()
     char ch;
     int num = 0;
 
-    for(ch = getch(),addch(ch),refresh(); 
-        ch >= '0' && ch <= '9'; 
-        ch = getch(),addch(ch),refresh())
+    for (ch = getch(), addch(ch), refresh(); ch >= '0' && ch <= '9';
+         ch = getch(), addch(ch), refresh())
     {
         num = num * 10 + ch - '0';
     }

--- a/monsters.c
+++ b/monsters.c
@@ -11,11 +11,14 @@
 #include <stdlib.h>
 #include <string.h>
 
-typedef struct { int d[2]; } direction;
+typedef struct
+{
+    int d[2];
+} direction;
 
 extern int debug_disp;
 extern int edit_mode;
-extern char screen[NOOFROWS][ROWLEN+1];
+extern char screen[NOOFROWS][ROWLEN + 1];
 
 /* Add a spirit to the chain */
 /* Maintain a doubly linked list to make reuse possible.
@@ -32,11 +35,11 @@ extern struct mon_rec start_of_list;
 *********************************************************/
 struct mon_rec *make_monster(int x, int y)
 {
-    #define MALLOC (struct mon_rec *)malloc(sizeof(struct mon_rec))
+#define MALLOC (struct mon_rec *)malloc(sizeof(struct mon_rec))
     struct mon_rec *monster;
-    if(tail_of_list->next == NULL)
+    if (tail_of_list->next == NULL)
     {
-        if((last_of_list = MALLOC) == NULL)
+        if ((last_of_list = MALLOC) == NULL)
             return NULL;
         tail_of_list->next = last_of_list;
         last_of_list->prev = tail_of_list;
@@ -45,7 +48,7 @@ struct mon_rec *make_monster(int x, int y)
     monster = tail_of_list = tail_of_list->next;
     monster->x = x;
     monster->y = y;
-    monster->mx = 1;      /* always start moving RIGHT. (fix later)  */
+    monster->mx = 1;            /* always start moving RIGHT. (fix later)  */
     monster->my = 0;
     monster->under = ' ';
     return monster;
@@ -59,25 +62,25 @@ struct mon_rec *make_monster(int x, int y)
 direction new_direction(int x, int y, int bx, int by)
 {
     direction out;
-    if(viable((x+by),(y-bx)))
+    if (viable((x + by), (y - bx)))
     {
         out.d[0] = by;
         out.d[1] = -bx;
         return out;
     }
-    if(viable((x+bx),(y+by)))
+    if (viable((x + bx), (y + by)))
     {
         out.d[0] = bx;
         out.d[1] = by;
         return out;
     }
-    if(viable((x-by),(y+bx)))
+    if (viable((x - by), (y + bx)))
     {
         out.d[0] = -by;
         out.d[1] = bx;
         return out;
     }
-    if(viable((x-bx),(y-by)))
+    if (viable((x - bx), (y - by)))
     {
         out.d[0] = -bx;
         out.d[1] = -by;
@@ -91,150 +94,167 @@ direction new_direction(int x, int y, int bx, int by)
 /***********************************************************
 *                   function move_monsters                 *
 ************************************************************/
-int move_monsters(int *mxp, int *myp, long *score, char *howdead, int sx, int sy, int nf, int bell, int x, int y, int diamonds)
+int move_monsters(int *mxp, int *myp, long *score, char *howdead, int sx,
+                  int sy, int nf, int bell, int x, int y, int diamonds)
 {
     int xdirection, ydirection, hd, vd;
     int deadyet = 0;
     direction new_disp;
-    struct mon_rec *monster,*current;
+    struct mon_rec *monster, *current;
     char buffer[25];
 
 /* big monster first */
-    if(*mxp == -2)                       /* has the monster been killed ? */
+    if (*mxp == -2)             /* has the monster been killed ? */
     {
-        *score+=100;
+        *score += 100;
         *mxp = *myp = -1;
-        move(3,48);
-        sprintf(buffer, "%ld\t %d\t", *score,nf);
+        move(3, 48);
+        sprintf(buffer, "%ld\t %d\t", *score, nf);
         addstr(buffer);
-        draw_symbol(50,11,' ');
-        move(12,56); addstr("              ");
-        move(13,56); addstr("              ");
-        move(16,0);
+        draw_symbol(50, 11, ' ');
+        move(12, 56);
+        addstr("              ");
+        move(13, 56);
+        addstr("              ");
+        move(16, 0);
         refresh();
-    }                                     /* if monster still alive */
+    }                           /* if monster still alive */
 
-    if(*mxp != -1)                        /* then move that monster ! */
+    if (*mxp != -1)             /* then move that monster ! */
     {
         screen[*myp][*mxp] = ' ';
-        if(*mxp>x)
+        if (*mxp > x)
             xdirection = -1;
         else
             xdirection = 1;
-        if(!debug_disp)
+        if (!debug_disp)
         {
-            if((*myp<(sy+4))&&(*myp>(sy-4))&&(*mxp<(sx+6))&&(*mxp>(sx-6)))
-                draw_symbol((*mxp-sx+5)*3,(*myp-sy+3)*2,' ');
+            if ((*myp < (sy + 4)) && (*myp > (sy - 4)) && (*mxp < (sx + 6))
+                && (*mxp > (sx - 6)))
+                draw_symbol((*mxp - sx + 5) * 3, (*myp - sy + 3) * 2, ' ');
         }
         else
         {
-            move(*myp+1,*mxp+1);
+            move(*myp + 1, *mxp + 1);
             addch(' ');
         }
-        if((hd = (*mxp-x))<0)
+        if ((hd = (*mxp - x)) < 0)
             hd = -hd;
-        if((vd = (*myp-y))<0)
+        if ((vd = (*myp - y)) < 0)
             vd = -vd;
-        if((hd>vd)&&((*mxp+xdirection)<ROWLEN)&&((screen[*myp][*mxp+xdirection] == ' ')||(screen[*myp][*mxp+xdirection] == '@')))
-            *mxp+=xdirection;
+        if ((hd > vd) && ((*mxp + xdirection) < ROWLEN)
+            && ((screen[*myp][*mxp + xdirection] == ' ')
+                || (screen[*myp][*mxp + xdirection] == '@')))
+            *mxp += xdirection;
         else
         {
-            if(*myp>y)
+            if (*myp > y)
                 ydirection = -1;
             else
                 ydirection = 1;
-            if(((*myp+ydirection)<NOOFROWS)&& ((screen[*myp+ydirection][*mxp]
-== ' ')||(screen[*myp+ydirection][*mxp] == '@')))
-                *myp+=ydirection;
-            else
-                if((((*mxp+xdirection)<ROWLEN)&&(screen[*myp][*mxp+xdirection] == ' '))||(screen[*myp][*mxp+xdirection] == '@'))
-            *mxp+=xdirection;
+            if (((*myp + ydirection) < NOOFROWS)
+                && ((screen[*myp + ydirection][*mxp] == ' ')
+                    || (screen[*myp + ydirection][*mxp] == '@')))
+                *myp += ydirection;
+            else if ((((*mxp + xdirection) < ROWLEN)
+                      && (screen[*myp][*mxp + xdirection] == ' '))
+                     || (screen[*myp][*mxp + xdirection] == '@'))
+                *mxp += xdirection;
         }
-        if(!debug_disp)
+        if (!debug_disp)
         {
-            if((*myp<(sy+4))&&(*myp>(sy-4))&&(*mxp<(sx+6))&&(*mxp>(sx-6)))
-                draw_symbol((*mxp-sx+5)*3,(*myp-sy+3)*2,'M');
+            if ((*myp < (sy + 4)) && (*myp > (sy - 4)) && (*mxp < (sx + 6))
+                && (*mxp > (sx - 6)))
+                draw_symbol((*mxp - sx + 5) * 3, (*myp - sy + 3) * 2, 'M');
         }
         else
         {
-            move(*myp+1,*mxp+1);
+            move(*myp + 1, *mxp + 1);
             addch('M');
         }
-        if(screen[*myp][*mxp] == '@')                     /* ha! gottim! */
+        if (screen[*myp][*mxp] == '@')  /* ha! gottim! */
         {
-            strcpy(howdead,"a hungry monster");
-            move(16,0);
+            strcpy(howdead, "a hungry monster");
+            move(16, 0);
             refresh();
             deadyet = 1;
         }
         screen[*myp][*mxp] = 'M';
-        move(16,0);
+        move(16, 0);
         refresh();
     }
 
-    current = &start_of_list;                         /* baby monsters now */
-    while((current != tail_of_list)&&(!deadyet))
-    /* deal with those little monsters */
+    current = &start_of_list;   /* baby monsters now */
+    while ((current != tail_of_list) && (!deadyet))
+        /* deal with those little monsters */
     {
         monster = current->next;
-        new_disp = new_direction( monster->x, monster->y, monster->mx, monster->my );
-        if(monster->under!='S')             /* if on top of another baby */
+        new_disp =
+            new_direction(monster->x, monster->y, monster->mx, monster->my);
+        if (monster->under != 'S')      /* if on top of another baby */
         {
             screen[monster->y][monster->x] = monster->under;
-            if(!debug_disp)
+            if (!debug_disp)
             {
-                if((monster->y < (sy+4)) && (monster->y > (sy-4)) && (monster->x < (sx+6)) && (monster->x > (sx-6)))
-                    draw_symbol((monster->x-sx+5)*3,(monster->y-sy+3)*2,monster->under);
+                if ((monster->y < (sy + 4)) && (monster->y > (sy - 4))
+                    && (monster->x < (sx + 6)) && (monster->x > (sx - 6)))
+                    draw_symbol((monster->x - sx + 5) * 3,
+                                (monster->y - sy + 3) * 2, monster->under);
             }
             else
             {
-                move(monster->y+1,monster->x+1);
+                move(monster->y + 1, monster->x + 1);
                 addch(monster->under);
             }
-            if(monster->under == ' ')
-                deadyet+=check(&*mxp,&*myp,monster->x,monster->y,new_disp.d[0],new_disp.d[1],sx,sy,howdead);
+            if (monster->under == ' ')
+                deadyet +=
+                    check(&*mxp, &*myp, monster->x, monster->y, new_disp.d[0],
+                          new_disp.d[1], sx, sy, howdead);
         }
         else
-            monster->under=' ';
+            monster->under = ' ';
         monster->mx = new_disp.d[0];
         monster->my = new_disp.d[1];
         monster->x += monster->mx;
         monster->y += monster->my;
         monster->under = screen[monster->y][monster->x];
-        screen[monster->y][monster->x] = 'S';        /* move into new space */
-        if(!debug_disp)
+        screen[monster->y][monster->x] = 'S';   /* move into new space */
+        if (!debug_disp)
         {
-            if((monster->y < (sy+4)) && (monster->y > (sy-4)) && (monster->x < (sx+6)) && (monster->x > (sx-6)))
-                draw_symbol((monster->x-sx+5)*3,(monster->y-sy+3)*2,'S');
+            if ((monster->y < (sy + 4)) && (monster->y > (sy - 4))
+                && (monster->x < (sx + 6)) && (monster->x > (sx - 6)))
+                draw_symbol((monster->x - sx + 5) * 3,
+                            (monster->y - sy + 3) * 2, 'S');
         }
         else
         {
-            move(monster->y+1,monster->x+1);
+            move(monster->y + 1, monster->x + 1);
             addch('S');
         }
-        if(monster->under == '@')                     /* monster hit you? */
+        if (monster->under == '@')      /* monster hit you? */
         {
-            strcpy(howdead,"the little monsters");
-            move(16,0);
+            strcpy(howdead, "the little monsters");
+            move(16, 0);
             refresh();
             deadyet = 1;
             monster->under = ' ';
         }
-        if(monster->under == '+')                    /* monster hit cage? */
+        if (monster->under == '+')      /* monster hit cage? */
         {
 #ifdef NOISY
-            if(bell) printf("\007");
+            if (bell)
+                printf("\007");
 #endif
-            *score +=20;
-            move(3,48);
+            *score += 20;
+            move(3, 48);
             sprintf(buffer, "%ld\t %d\t %d ", *score, nf, diamonds);
             addstr(buffer);
-        /* remove from chain, and insert at the end (at last_of_list) */
-            if(monster == tail_of_list)
+            /* remove from chain, and insert at the end (at last_of_list) */
+            if (monster == tail_of_list)
                 tail_of_list = tail_of_list->prev;
             else
             {
-                current->next = monster-> next;
+                current->next = monster->next;
                 current->next->prev = current;
                 monster->next = NULL;
                 monster->prev = last_of_list;
@@ -242,20 +262,22 @@ int move_monsters(int *mxp, int *myp, long *score, char *howdead, int sx, int sy
                 last_of_list = monster;
             }
             screen[monster->y][monster->x] = '*';
-            if(!debug_disp)
+            if (!debug_disp)
             {
-                if((monster->y < (sy+4)) && (monster->y > (sy-4)) && (monster->x < (sx+6)) && (monster->x > (sx-6)))
-                    draw_symbol((monster->x-sx+5)*3,(monster->y-sy+3)*2,'*');
+                if ((monster->y < (sy + 4)) && (monster->y > (sy - 4))
+                    && (monster->x < (sx + 6)) && (monster->x > (sx - 6)))
+                    draw_symbol((monster->x - sx + 5) * 3,
+                                (monster->y - sy + 3) * 2, '*');
             }
             else
             {
-                move(monster->y+1,monster->x+1);
+                move(monster->y + 1, monster->x + 1);
                 addch('*');
             }
         }
         else
             current = monster;
-        move(16,0);
+        move(16, 0);
         refresh();
     }
     return deadyet;

--- a/monsters.c
+++ b/monsters.c
@@ -113,9 +113,9 @@ int move_monsters(int *mxp, int *myp, long *score, char *howdead, int sx,
         addstr(buffer);
         draw_symbol(50, 11, ' ');
         move(12, 56);
-        addstr("              ");
+        printw("%14s", "");
         move(13, 56);
-        addstr("              ");
+        printw("%14s", "");
         move(16, 0);
         refresh();
     }                           /* if monster still alive */

--- a/monsters.h
+++ b/monsters.h
@@ -10,13 +10,15 @@
 
 struct mon_rec
 {
-    int x,y,mx,my;
+    int x, y, mx, my;
     char under;
-    struct mon_rec *next,*prev;
+    struct mon_rec *next, *prev;
 };
 
 struct mon_rec *make_monster(int x, int y);
 
-int move_monsters(int *mxp, int *myp, long *score, char *howdead, int sx, int sy, int nf, int bell, int x, int y, int diamonds);
+int move_monsters(int *mxp, int *myp, long *score, char *howdead,
+                  int sx, int sy, int nf, int bell, int x, int y,
+                  int diamonds);
 
 #endif // __MONSTERS_H

--- a/passwords.c
+++ b/passwords.c
@@ -14,27 +14,28 @@
 ****************************************************/
 int scrn_passwd(int num, char *passwd)
 {
-        long position;
-        FILE *fp;
+    long position;
+    FILE *fp;
 
-        position = PASSWD;
-        if(position < 0)
-                position = -position;
-        while(position > 200000)
-                position -= 200000;
-        if(position > 198500)
-                position -=198500;
-        if((fp = fopen(DICTIONARY,"r")) == NULL)
-                return 0;
-        fseek(fp,position,ftell(fp));
-        while(fgetc(fp) != '\n');
-        if (fscanf(fp,"%s\n",passwd) == EOF && errno != 0) {
-            fprintf(stderr, "fscanf error\n");
-            exit(EXIT_FAILURE);
-        }
-        /* read a word into passwd */
-        fclose(fp);
-        return (1);
+    position = PASSWD;
+    if (position < 0)
+        position = -position;
+    while (position > 200000)
+        position -= 200000;
+    if (position > 198500)
+        position -= 198500;
+    if ((fp = fopen(DICTIONARY, "r")) == NULL)
+        return 0;
+    fseek(fp, position, ftell(fp));
+    while (fgetc(fp) != '\n');
+    if (fscanf(fp, "%s\n", passwd) == EOF && errno != 0)
+    {
+        fprintf(stderr, "fscanf error\n");
+        exit(EXIT_FAILURE);
+    }
+    /* read a word into passwd */
+    fclose(fp);
+    return (1);
 }
 
 /************************************************
@@ -42,37 +43,44 @@ int scrn_passwd(int num, char *passwd)
 *************************************************/
 int main(int argc, char **argv)
 {
-        int scr,position,mpw = 0;
-        char pass[20];
-        char pw[100];
-        if(argc < 2) {
-                printf("Usage: %s screen1 screen2 ...\n",argv[0]);
+    int scr, position, mpw = 0;
+    char pass[20];
+    char pw[100];
+    if (argc < 2)
+    {
+        printf("Usage: %s screen1 screen2 ...\n", argv[0]);
+        exit(-1);
+    }
+    position = 0;
+    while (++position < argc)
+    {
+        if (atoi(argv[position]) < 1)
+        {
+            printf("Option not known: %s.\n", argv[position]);
+            continue;
+        }
+        scr = atoi(argv[position]);
+        if ((scr < 100) && (mpw == 0))
+        {
+            printf("You need clearance to see passwords below 100.\n");
+            printf("Enter master password:");
+            if (scanf("%s", pw) == EOF && errno != 0)
+            {
+                fprintf(stderr, "scanf error\n");
+                exit(EXIT_FAILURE);
+            }
+            if (strncmp(pw, PASS, strlen(PASS)))
+            {
+                printf("Foo, charlatan!\n");
                 exit(-1);
+            }
+            mpw = 1;
         }
-        position = 0;
-        while(++position < argc) {
-                if(atoi(argv[position])<1) {
-                        printf("Option not known: %s.\n",argv[position]);
-                        continue;
-                }
-                scr = atoi(argv[position]);
-                if((scr < 100) && (mpw == 0)) {
-                        printf("You need clearance to see passwords below 100.\n");
-                        printf("Enter master password:");
-                        if (scanf("%s", pw) == EOF && errno != 0) {
-                            fprintf(stderr, "scanf error\n");
-                            exit(EXIT_FAILURE);
-                        }
-                        if(strncmp(pw,PASS,strlen(PASS))) {
-                                printf("Foo, charlatan!\n");
-                                exit(-1);
-                        }
-                        mpw = 1;
-                }
-                if( ! scrn_passwd((scr-1),pass)) {
-                        printf("%s: Cannot access %s.\n",argv[0],DICTIONARY);
-                        exit(-1);
-                }
-                printf("Screen %d password is '%s'.\n",scr,pass);
+        if (!scrn_passwd((scr - 1), pass))
+        {
+            printf("%s: Cannot access %s.\n", argv[0], DICTIONARY);
+            exit(-1);
         }
+        printf("Screen %d password is '%s'.\n", scr, pass);
+    }
 }

--- a/read.c
+++ b/read.c
@@ -13,7 +13,7 @@ extern int inform_me();
 
 extern int edit_mode;
 extern char *edit_screen;
-extern char screen[NOOFROWS][ROWLEN+1];
+extern char screen[NOOFROWS][ROWLEN + 1];
 
 extern char screen_name[61];
 
@@ -24,48 +24,51 @@ char buffer[80];
 *****************************************************************************/
 int rscreen(int num, int *maxmoves)
 {
-    int  y,numr;
+    int y, numr;
     FILE *fp;
     char name[100];
-    char (*row_ptr)[ROWLEN+1] = screen;
-    if(!edit_mode)
-        sprintf(name,"%s/screen.%d",SCREENPATH,num);
+    char (*row_ptr)[ROWLEN + 1] = screen;
+    if (!edit_mode)
+        sprintf(name, "%s/screen.%d", SCREENPATH, num);
     else
     {
-        if(!edit_screen)
-            sprintf(name,"./screen");
+        if (!edit_screen)
+            sprintf(name, "./screen");
         else
-            sprintf(name,"%s",edit_screen);
+            sprintf(name, "%s", edit_screen);
     }
-    
-    if((fp = fopen(name,"r"))== NULL)
+
+    if ((fp = fopen(name, "r")) == NULL)
     {
-        if(edit_mode)
-            sprintf(buffer,"Cannot find file %s.",name);
+        if (edit_mode)
+            sprintf(buffer, "Cannot find file %s.", name);
         else
-            sprintf(buffer,"File for screen %d unavailable.",num);
-        inform_me(buffer,0);
+            sprintf(buffer, "File for screen %d unavailable.", num);
+        inform_me(buffer, 0);
     }
     else
     {
-        for(y = 0;y<NOOFROWS;y++)
+        for (y = 0; y < NOOFROWS; y++)
         {
-            if (fgets(*row_ptr,ROWLEN + 2,fp) == NULL) {
+            if (fgets(*row_ptr, ROWLEN + 2, fp) == NULL)
+            {
                 fprintf(stderr, "fgets error\n");
                 exit(EXIT_FAILURE);
             }
-            numr = strlen( *row_ptr ) - 1;
-            while(numr < ROWLEN) (*row_ptr)[numr++] = ' ';
+            numr = strlen(*row_ptr) - 1;
+            while (numr < ROWLEN)
+                (*row_ptr)[numr++] = ' ';
             row_ptr++;
         };
-        if (fgets(screen_name,60,fp) == NULL) {
+        if (fgets(screen_name, 60, fp) == NULL)
+        {
             fprintf(stderr, "fgets error\n");
             exit(EXIT_FAILURE);
         }
         screen_name[61] = '\0';
-        screen_name[strlen(screen_name)-1] = '\0';
-        if(fscanf(fp,"%d",maxmoves) != 1)
-            *maxmoves=0;
+        screen_name[strlen(screen_name) - 1] = '\0';
+        if (fscanf(fp, "%d", maxmoves) != 1)
+            *maxmoves = 0;
         fclose(fp);
     };
     return (fp == NULL);
@@ -76,46 +79,46 @@ int rscreen(int num, int *maxmoves)
 **********************************************************************/
 int wscreen(int maxmoves)
 {
-    int  y,x;
+    int y, x;
     FILE *fp;
     char name[100];
-    char (*row_ptr)[ROWLEN+1] = screen;
-    
-    if(!edit_screen)
-        sprintf(name,"./screen");
+    char (*row_ptr)[ROWLEN + 1] = screen;
+
+    if (!edit_screen)
+        sprintf(name, "./screen");
     else
-        sprintf(name,"%s",edit_screen);
-    
-    if((fp = fopen(name,"w")) == NULL)
+        sprintf(name, "%s", edit_screen);
+
+    if ((fp = fopen(name, "w")) == NULL)
     {
-        sprintf(name,"/tmp/screen.%d",getpid());
-        if((fp = fopen(name,"w")) != NULL)
+        sprintf(name, "/tmp/screen.%d", getpid());
+        if ((fp = fopen(name, "w")) != NULL)
         {
-            sprintf(buffer,"Written file is %s",name);
-            inform_me(buffer,0);
+            sprintf(buffer, "Written file is %s", name);
+            inform_me(buffer, 0);
         }
         else
-            err(1,"Could not open %s.\n",buffer);
+            err(1, "Could not open %s.\n", buffer);
     }
-    if(fp == NULL)
+    if (fp == NULL)
     {
-        inform_me("File for screen cannot be written.",0) ;
+        inform_me("File for screen cannot be written.", 0);
     }
     else
     {
-        for(y = 0;y<NOOFROWS;y++)
+        for (y = 0; y < NOOFROWS; y++)
         {
-            for(x = 0;x<ROWLEN;x++)
-                fputc(row_ptr[y][x],fp);
-            fputc('\n',fp);
+            for (x = 0; x < ROWLEN; x++)
+                fputc(row_ptr[y][x], fp);
+            fputc('\n', fp);
         };
-        if( *screen_name == '\0' )
-            fputc('#',fp);
+        if (*screen_name == '\0')
+            fputc('#', fp);
         else
-            fputs(screen_name,fp);
-        fputc('\n',fp);
-        if(maxmoves != 0)
-            fprintf(fp,"%d\n",maxmoves);
+            fputs(screen_name, fp);
+        fputc('\n', fp);
+        if (maxmoves != 0)
+            fprintf(fp, "%d\n", maxmoves);
         fclose(fp);
     };
     return (fp == NULL);

--- a/read.c
+++ b/read.c
@@ -14,6 +14,7 @@ extern int inform_me();
 extern int edit_mode;
 extern char *edit_screen;
 extern char screen[NOOFROWS][ROWLEN + 1];
+extern char *screenpath;
 
 extern char screen_name[61];
 
@@ -29,7 +30,7 @@ int rscreen(int num, int *maxmoves)
     char name[100];
     char (*row_ptr)[ROWLEN + 1] = screen;
     if (!edit_mode)
-        sprintf(name, "%s/screen.%d", SCREENPATH, num);
+        sprintf(name, "%s/screen.%d", screenpath, num);
     else
     {
         if (!edit_screen)

--- a/save.c
+++ b/save.c
@@ -13,9 +13,9 @@
 #include <string.h>
 #include <unistd.h>
 
-extern char screen[NOOFROWS][ROWLEN+1];
+extern char screen[NOOFROWS][ROWLEN + 1];
 extern int saved_game;
-extern char screen_name[ROWLEN+1];
+extern char screen_name[ROWLEN + 1];
 
 struct saved_game
 {
@@ -26,7 +26,7 @@ struct saved_game
     short num_monsters;
 };
 
-struct save_vars  zz;
+struct save_vars zz;
 
 extern struct mon_rec start_of_list, *tail_of_list;
 
@@ -35,79 +35,80 @@ extern struct mon_rec start_of_list, *tail_of_list;
 **********************************************************/
 void save_game(int num, long *score, int *bell, int maxmoves)
 {
-        char   fname[128], buf[70], *fp;
-        FILE   *fo;
-        struct saved_game  s;
-        struct mon_rec     *mp;
+    char fname[128], buf[70], *fp;
+    FILE *fo;
+    struct saved_game s;
+    struct mon_rec *mp;
 
-        if ((char *)NULL == (fp = getenv("SAVENAME")))
-        {
-            move(20,0);
-            addstr("Saving: Filename? ");
-            refresh();
-            readstring(fname,127);
-            fp = fname;
-        }
-        move(20,0);
-        addstr("                                                                             ");
-        move(20,0);
+    if ((char *) NULL == (fp = getenv("SAVENAME")))
+    {
+        move(20, 0);
+        addstr("Saving: Filename? ");
         refresh();
-        if ((FILE *)NULL == (fo = fopen(fp, W_BIN)))
+        readstring(fname, 127);
+        fp = fname;
+    }
+    move(20, 0);
+    addstr
+        ("                                                                             ");
+    move(20, 0);
+    refresh();
+    if ((FILE *) NULL == (fo = fopen(fp, W_BIN)))
+    {
+        perror(fp);
+        return;
+    }
+
+    s.num = num;
+    s.score = *score;
+    s.bell = *bell;
+    s.maxmoves = maxmoves;
+    s.num_monsters = 0;
+
+    mp = &start_of_list;        /* first entry is dummy        */
+    while (mp != tail_of_list)
+    {
+        mp = mp->next;
+        s.num_monsters++;       /* count them monsters        */
+    }
+
+    if ((1 != fwrite((char *) &s, sizeof(s), 1, fo))
+        || (1 != fwrite((char *) screen, sizeof(screen), 1, fo))
+        || (1 != fwrite((char *) &zz, sizeof(zz), 1, fo)))
+    {
+        sprintf(buf, "Write error on '%s'\n", fname);
+        inform_me(buf, 0);
+        fclose(fo);
+        unlink(fname);
+        return;
+    }
+
+    mp = &start_of_list;
+    while (mp != tail_of_list)
+    {
+        /* save them monsters */
+        mp = mp->next;
+        if (1 != fwrite((char *) mp, sizeof(struct mon_rec), 1, fo))
         {
-            perror(fp);
+            sprintf(buf, "Write error on '%s'\n", fname);
+            inform_me(buf, 0);
+            fclose(fo);
+            unlink(fname);
             return;
         }
-
-        s.num = num;
-        s.score = *score;
-        s.bell = *bell;
-        s.maxmoves = maxmoves;
-        s.num_monsters = 0;
-
-        mp = &start_of_list;                /* first entry is dummy        */
-        while (mp != tail_of_list)
-        {
-                mp = mp->next;
-                s.num_monsters++;        /* count them monsters        */
-        }
-
-        if ( (1 != fwrite((char *)&s, sizeof(s), 1, fo)) ||
-             (1 != fwrite((char *)screen, sizeof(screen), 1, fo)) ||
-             (1 != fwrite((char *)&zz, sizeof(zz), 1, fo)) )
-        {
-             sprintf(buf,"Write error on '%s'\n", fname);
-             inform_me(buf,0);
-             fclose(fo);
-             unlink(fname);
-             return;
-        }
-
-        mp = &start_of_list;
-        while (mp != tail_of_list)
-        {
-        /* save them monsters */
-            mp = mp->next;
-            if(1 != fwrite((char *)mp, sizeof(struct mon_rec), 1, fo))
-            {
-                sprintf(buf,"Write error on '%s'\n", fname);
-                inform_me(buf, 0);
-                fclose(fo);
-                unlink(fname);
-                return;
-            }
-        }
-        fwrite(screen_name,sizeof(char),strlen(screen_name),fo);
-        fclose(fo);
+    }
+    fwrite(screen_name, sizeof(char), strlen(screen_name), fo);
+    fclose(fo);
 #ifndef NO_ENCRYPTION
-        crypt_file(fp);   /* encrpyt the saved game */
+    crypt_file(fp);             /* encrpyt the saved game */
 #endif
-        clear();
-        CBON;
-        echo();
-        refresh();
-        endwin();
-        printf("Game saved.\n\nWanderer Copyright (C) 1988 S Shipway\n\n");
-        exit(0);
+    clear();
+    CBON;
+    echo();
+    refresh();
+    endwin();
+    printf("Game saved.\n\nWanderer Copyright (C) 1988 S Shipway\n\n");
+    exit(0);
 }
 
 /*************************************************
@@ -115,34 +116,34 @@ void save_game(int num, long *score, int *bell, int maxmoves)
 **************************************************/
 void restore_game(int *num, long *score, int *bell, int *maxmoves)
 {
-    FILE        *fi;
-    struct        saved_game        s;
-    struct        mon_rec        *mp, *tmp, tmp_monst;
-    char        fname[128], *fp;
+    FILE *fi;
+    struct saved_game s;
+    struct mon_rec *mp, *tmp, tmp_monst;
+    char fname[128], *fp;
 
-    if ((char *)NULL == (fp = getenv("SAVENAME")))
+    if ((char *) NULL == (fp = getenv("SAVENAME")))
     {
-        move((LINES-1),0);
+        move((LINES - 1), 0);
         addstr("Restore Filename ? ");
         refresh();
-        readstring(fname,127);
+        readstring(fname, 127);
         fp = fname;
     }
     clear();
     refresh();
 #ifndef NO_ENCRYPTION
-     crypt_file(fp);   /* decrypt it */
+    crypt_file(fp);             /* decrypt it */
 #endif
-    if ((FILE *)NULL == (fi = fopen(fp, R_BIN)))
+    if ((FILE *) NULL == (fi = fopen(fp, R_BIN)))
     {
         endwin();
         printf("Open error on '%s'\n", fp);
         printf("Cannot restore game --- sorry.\n");
         exit(1);
     }
-    if ( (1 != fread((char *)&s, sizeof(s), 1, fi)) ||
-         (1 != fread((char *)screen, sizeof(screen), 1, fi)) ||
-         (1 != fread((char *)&zz, sizeof(zz), 1, fi)) )
+    if ((1 != fread((char *) &s, sizeof(s), 1, fi))
+        || (1 != fread((char *) screen, sizeof(screen), 1, fi))
+        || (1 != fread((char *) &zz, sizeof(zz), 1, fi)))
     {
         endwin();
         printf("Read error on '%s'n", fp);
@@ -160,7 +161,7 @@ void restore_game(int *num, long *score, int *bell, int *maxmoves)
     mp = start_of_list.next;
     while ((mp != NULL) && (mp != &start_of_list))
     {
-    /* free them monsters        */
+        /* free them monsters        */
         tmp = mp;
         mp = mp->next;
         free(tmp);
@@ -173,16 +174,16 @@ void restore_game(int *num, long *score, int *bell, int *maxmoves)
     start_of_list.mx = 0;
     start_of_list.my = 0;
     start_of_list.under = 0;
-    start_of_list.next = (struct mon_rec *)NULL;
-    start_of_list.prev = (struct mon_rec *)NULL;
+    start_of_list.next = (struct mon_rec *) NULL;
+    start_of_list.prev = (struct mon_rec *) NULL;
 
     tail_of_list = &start_of_list;
 
-    while(s.num_monsters--)
+    while (s.num_monsters--)
     {
-    /* use make_monster to allocate the monster structures     */
-    /* to get all the linking right without even trying        */
-        if ((struct mon_rec *)NULL == (mp = make_monster(0, 0)))
+        /* use make_monster to allocate the monster structures     */
+        /* to get all the linking right without even trying        */
+        if ((struct mon_rec *) NULL == (mp = make_monster(0, 0)))
         {
             endwin();
             printf("Monster alloc error on '%s'n", fp);
@@ -190,7 +191,7 @@ void restore_game(int *num, long *score, int *bell, int *maxmoves)
             fclose(fi);
             exit(1);
         }
-        if(1 != fread((char *)&tmp_monst, sizeof(struct mon_rec),1,fi))
+        if (1 != fread((char *) &tmp_monst, sizeof(struct mon_rec), 1, fi))
         {
             endwin();
             printf("Monster read error on '%s'\n", fp);
@@ -199,13 +200,13 @@ void restore_game(int *num, long *score, int *bell, int *maxmoves)
             exit(1);
         }
         /* copy info without trashing links        */
-        mp->x     = tmp_monst.x;
-        mp->y     = tmp_monst.y;
-        mp->mx    = tmp_monst.mx;
-        mp->my    = tmp_monst.my;
+        mp->x = tmp_monst.x;
+        mp->y = tmp_monst.y;
+        mp->mx = tmp_monst.mx;
+        mp->my = tmp_monst.my;
         mp->under = tmp_monst.under;
     }
-    if(fgets(screen_name,ROWLEN,fi) == NULL)
+    if (fgets(screen_name, ROWLEN, fi) == NULL)
         *screen_name = '#';
     fclose(fi);
     unlink(fp);

--- a/save.c
+++ b/save.c
@@ -49,8 +49,7 @@ void save_game(int num, long *score, int *bell, int maxmoves)
         fp = fname;
     }
     move(20, 0);
-    addstr
-        ("                                                                             ");
+    printw("%77s", "");
     move(20, 0);
     refresh();
     if ((FILE *) NULL == (fo = fopen(fp, W_BIN)))

--- a/save.h
+++ b/save.h
@@ -3,31 +3,16 @@
 
 /* Save and Restore game additions (M002) by Gregory H. Margo        */
 
-struct        save_vars        {
-        int        z_x, z_y,
-                z_sx, z_sy,
-                z_tx, z_ty,
-                z_mx, z_my,
-                z_diamonds,
-                z_nf;
+struct save_vars
+{
+    int z_x, z_y, z_sx, z_sy, z_tx, z_ty, z_mx, z_my, z_diamonds, z_nf;
 };
 
-struct        old_save_vars        {
-        int        z_x, z_y,
-                z_nx, z_ny,
-                z_sx, z_sy,
-                z_tx, z_ty,
-                z_lx, z_ly,
-                z_mx, z_my,
-                z_bx, z_by,
-                z_nbx, z_nby,
-                z_max_score,
-                z_diamonds,
-                z_nf,
-                z_hd,
-                z_vd,
-                z_xdirection,
-                z_ydirection;
+struct old_save_vars
+{
+    int z_x, z_y, z_nx, z_ny, z_sx, z_sy, z_tx, z_ty, z_lx, z_ly,
+        z_mx, z_my, z_bx, z_by, z_nbx, z_nby, z_max_score, z_diamonds, z_nf,
+        z_hd, z_vd, z_xdirection, z_ydirection;
 };
 
 #ifndef __CONVERT

--- a/scores.c
+++ b/scores.c
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-#ifdef  MSDOS        /* M001 */
+#ifdef  MSDOS                   /* M001 */
 
 #define LOCK
 #define UNLOCK
@@ -19,13 +19,13 @@
 /*#define UNLOCK   flock( fp->_cnt , LOCK_UN )                        */
 /* #define LOCK while((lock = creat(LOCKFILE,0))==-1) Not a good way  */
 
-#define LOCK if((lock = open(LOCKFILE, O_CREAT | O_TRUNC | O_WRONLY, "r"))==-1){errx (1,"%s","Lockfile creation failed\n"); exit(1);} /* Marina */
+#define LOCK if((lock = open(LOCKFILE, O_CREAT | O_TRUNC | O_WRONLY, "r"))==-1){errx (1,"%s","Lockfile creation failed\n"); exit(1);}   /* Marina */
 
 #define UNLOCK unlink(LOCKFILE)
 
 #endif
 
-#ifdef    MSDOS        /* M001 */
+#ifdef    MSDOS                 /* M001 */
 #define   getuid()        0
 #endif
 
@@ -35,7 +35,7 @@
 #define   SAMEUSER(p)        ((p)->uid == user_id)
 #endif
 
-extern int saved_game;  /* prevent recording of hiscore if  */
+extern int saved_game;          /* prevent recording of hiscore if  */
                         /* NO_RESTORED_GAME_HISCORES is #def'd */
 
 /***********************************
@@ -46,12 +46,12 @@ typedef struct
     char howdead[25];
     char name[20];
     long score;
-    int  level;
-    int  uid;
+    int level;
+    int uid;
 } score_entry;
 
-#ifdef LINT_ARGS  /* M001 */
-void show_scores(score_entry *,int );
+#ifdef LINT_ARGS                /* M001 */
+void show_scores(score_entry *, int);
 int readtable(score_entry *);
 #else
 void show_scores();
@@ -62,16 +62,19 @@ int readtable();
 /************************
 *      show_scores      *
 *************************/
-void show_scores(score_entry *table,int num)
+void show_scores(score_entry * table, int num)
 {
     int tot = num;
 
-    printf("\nNo. Score Level           Names                 How they died\n");
-    printf("=============================================================================\n");
-    while(num > 0)
+    printf
+        ("\nNo. Score Level           Names                 How they died\n");
+    printf
+        ("=============================================================================\n");
+    while (num > 0)
     {
         num--;
-        printf("%2d %5ld %3d      %-20s     killed by %-s\n", (tot - num), table->score, table->level, table->name, table->howdead);
+        printf("%2d %5ld %3d      %-20s     killed by %-s\n", (tot - num),
+               table->score, table->level, table->name, table->howdead);
         table++;
     }
     printf("\n\n");
@@ -81,18 +84,18 @@ void show_scores(score_entry *table,int num)
 /*************************
 *   readtable function   *
 **************************/
-int readtable(score_entry *table_ptr)
+int readtable(score_entry * table_ptr)
 {
     FILE *fp;
-    int  numread;
+    int numread;
 
-    if((fp = fopen(HISCOREPATH,R_BIN)) == NULL)
+    if ((fp = fopen(HISCOREPATH, R_BIN)) == NULL)
     {
         numread = 0;
     }
     else
     {
-        numread = fread( VOIDSTAR table_ptr, sizeof(score_entry), ENTRIES, fp);
+        numread = fread(VOIDSTAR table_ptr, sizeof(score_entry), ENTRIES, fp);
         fclose(fp);
     }
     return numread;
@@ -105,24 +108,21 @@ int readtable(score_entry *table_ptr)
 
 int savescore(char *howdead, long score, int level, char *name)
 {
-    score_entry table[ENTRIES + 2],
-                *table_ptr = table,
-                new_entry,
-                temp_entry;
+    score_entry table[ENTRIES + 2], *table_ptr = table, new_entry, temp_entry;
     int numread;
-    int index = 1; 
+    int index = 1;
     int numsaved;
-    int lock; 
-    int already = 0; 
+    int lock;
+    int already = 0;
     int output_value = 1;
-    int user_id; 
+    int user_id;
     int position;
 
     FILE *fp;
 
 #ifdef NO_RESTORED_GAME_HISCORES
 
-    if(saved_game)
+    if (saved_game)
     {
         printf("No hiscores recorded from restored games.\n");
         printf("\nWanderer (C) 1988  S.Shipway.\n\n");
@@ -131,35 +131,35 @@ int savescore(char *howdead, long score, int level, char *name)
 #endif
 
     user_id = getuid();
-    strncpy(new_entry.howdead,howdead,25);
-    new_entry.howdead[24] = '\0'; /* M002 strncpy does not null terminate */
-    strncpy(new_entry.name,name,20);
-    new_entry.name[19] = '\0'; /* M002 strncpy does not null terminate */
+    strncpy(new_entry.howdead, howdead, 25);
+    new_entry.howdead[24] = '\0';       /* M002 strncpy does not null terminate */
+    strncpy(new_entry.name, name, 20);
+    new_entry.name[19] = '\0';  /* M002 strncpy does not null terminate */
     new_entry.score = score;
     new_entry.level = level;
     new_entry.uid = user_id;
-    LOCK;    /* BUG is HERE !!! */
+    LOCK;                       /* BUG is HERE !!! */
     numread = readtable(table_ptr);
     if (numread > 0)
-        if(table[numread-1].score > 99999) /* stop system errors messing it up*/
+        if (table[numread - 1].score > 99999)   /* stop system errors messing it up */
         {
             numread--;
             printf("Erasing spurious entry in table.\n");
         }
-    if(score == -1)
+    if (score == -1)
     {
-        show_scores(table,numread);
+        show_scores(table, numread);
         UNLOCK;
         return 0;
     }
 /* HERE */
     if (numread > 0)
     {
-        numread++; /* scan through until correct insertion point */
+        numread++;              /* scan through until correct insertion point */
         /* pass table entries with higher scores */
-        while((table_ptr->score > score)&&(index < numread))
+        while ((table_ptr->score > score) && (index < numread))
         {
-            if(SAMEUSER(table_ptr))
+            if (SAMEUSER(table_ptr))
             {
                 already = 1;
                 break;
@@ -167,13 +167,12 @@ int savescore(char *howdead, long score, int level, char *name)
             table_ptr++;
             index++;
         }
-       /* pass table entries with equal score but higher or equal level */
+        /* pass table entries with equal score but higher or equal level */
 
-        while((table_ptr->level>=level)&&
-            (index<numread)&&
-            (table_ptr->score==score))
+        while ((table_ptr->level >= level) && (index < numread)
+               && (table_ptr->score == score))
         {
-            if(SAMEUSER(table_ptr))
+            if (SAMEUSER(table_ptr))
             {
                 already = 1;
                 break;
@@ -183,35 +182,36 @@ int savescore(char *howdead, long score, int level, char *name)
         }
         position = index;
         /* if already found: done */
-       if(already == 1)
-       {
-           numread--;
-           UNLOCK;
-           return numread;
-       }
-    /* shift down score list */
-       while(index < numread)
-       {
-           /* swap *table_ptr and new_entry */
-           temp_entry = *table_ptr;
-           *table_ptr = new_entry;
-           new_entry = temp_entry;
-           if(SAMEUSER(&new_entry))
-           {
-               already = 1;
-               numread--; /* an older entry found */
-               break;
-           }
-           table_ptr++;
-           index++;
-       }
-       /* if all shifted without finding an older entry */
-       if(already==0)
-           *table_ptr = new_entry;
-       if( position <= ENTRIES )
-           printf("You rank %d in the hiscore table.\n",position);
-       else
-           printf("Sorry, you didnt make it into the hiscore table this time.\n");
+        if (already == 1)
+        {
+            numread--;
+            UNLOCK;
+            return numread;
+        }
+        /* shift down score list */
+        while (index < numread)
+        {
+            /* swap *table_ptr and new_entry */
+            temp_entry = *table_ptr;
+            *table_ptr = new_entry;
+            new_entry = temp_entry;
+            if (SAMEUSER(&new_entry))
+            {
+                already = 1;
+                numread--;      /* an older entry found */
+                break;
+            }
+            table_ptr++;
+            index++;
+        }
+        /* if all shifted without finding an older entry */
+        if (already == 0)
+            *table_ptr = new_entry;
+        if (position <= ENTRIES)
+            printf("You rank %d in the hiscore table.\n", position);
+        else
+            printf
+                ("Sorry, you didnt make it into the hiscore table this time.\n");
     }
     else
     {
@@ -219,23 +219,25 @@ int savescore(char *howdead, long score, int level, char *name)
         *table_ptr = new_entry;
         numread++;
     }
-    numread = ( (numread > ENTRIES) ? ENTRIES : numread );
-    
-    if((fp = fopen(HISCOREPATH,W_BIN)) != NULL)
+    numread = ((numread > ENTRIES) ? ENTRIES : numread);
+
+    if ((fp = fopen(HISCOREPATH, W_BIN)) != NULL)
     {
         table_ptr = table;
-        numsaved = fwrite(VOIDSTAR table_ptr, sizeof(score_entry), numread, fp);
-        chmod(HISCOREPATH,0666);
-        if(numsaved < numread)
+        numsaved =
+            fwrite(VOIDSTAR table_ptr, sizeof(score_entry), numread, fp);
+        chmod(HISCOREPATH, 0666);
+        if (numsaved < numread)
         {
-            printf("ERROR! Only %d items saved from %d !\n",numsaved,numread);
+            printf("ERROR! Only %d items saved from %d !\n", numsaved,
+                   numread);
             output_value = 0;
         }
         fclose(fp);
     }
     else
-        err(1,"%s","Error in savescore - fopen HISCOREPATH failed\n");
-    
+        err(1, "%s", "Error in savescore - fopen HISCOREPATH failed\n");
+
     UNLOCK;
     return output_value;
 }
@@ -246,51 +248,54 @@ int savescore(char *howdead, long score, int level, char *name)
 **************************/
 void delete_entry(int num)
 {
-    score_entry table[ENTRIES + 22],
-                  *table_ptr = table;
-    int  numread,index = 1, numsaved, lock;
+    score_entry table[ENTRIES + 22], *table_ptr = table;
+    int numread, index = 1, numsaved, lock;
     FILE *fp;
 
     LOCK;
     numread = readtable(table_ptr);
-    if (numread == 0) {
+    if (numread == 0)
+    {
         printf("Missing or unreadable hiscore table.\n\n");
         UNLOCK;
         exit(1);
     }
-    if (num > numread) {
+    if (num > numread)
+    {
         printf("Invalid entry, choose again\n");
         UNLOCK;
         return;
     }
-    while(index < num)
+    while (index < num)
     {
         index++;
         table_ptr++;
     }
-    while(index < numread)
+    while (index < numread)
     {
         index++;
-        *table_ptr = *(table_ptr+1);
+        *table_ptr = *(table_ptr + 1);
         table_ptr++;
     }
     numread--;
-    
-    if((fp = fopen(HISCOREPATH,W_BIN)) != NULL)
+
+    if ((fp = fopen(HISCOREPATH, W_BIN)) != NULL)
     {
         table_ptr = table;
-        numsaved = fwrite(VOIDSTAR table_ptr, sizeof(score_entry), numread, fp);
-        chmod(HISCOREPATH,0666);
-        if(numsaved < numread)
+        numsaved =
+            fwrite(VOIDSTAR table_ptr, sizeof(score_entry), numread, fp);
+        chmod(HISCOREPATH, 0666);
+        if (numsaved < numread)
         {
-            printf("ERROR! Only %d items saved from %d !\n",numsaved,numread);
+            printf("ERROR! Only %d items saved from %d !\n", numsaved,
+                   numread);
         }
         fclose(fp);
     }
     else
         err(1, "%s", "Could not open Scorefile\n");
     UNLOCK;
-    show_scores(table,numsaved);
+    show_scores(table, numsaved);
 }
 
 /**/
@@ -306,29 +311,30 @@ void erase_scores()
     score_entry table[ENTRIES + 2], *table_ptr = table;
 
     printf("Please enter password:");
-    while((c = getchar()) != '\n' && index <19)
+    while ((c = getchar()) != '\n' && index < 19)
     {
         correct[index++] = c;
     }
     correct[index] = 0;
-    if(strcmp(correct,MASTERPASSWORD))
+    if (strcmp(correct, MASTERPASSWORD))
     {
         printf("\nFoo, charlatan!\n");
         return;
     }
     numread = readtable(table_ptr);
-    show_scores(table,numread);
+    show_scores(table, numread);
     printf("\n");
 
-    for(;;)
+    for (;;)
     {
         printf("Number to erase (0 to exit): ");
-        if (scanf("%d",&erasenum) == EOF && errno != 0) {
-          fprintf(stderr, "scanf error\n");
-          exit(EXIT_FAILURE);
+        if (scanf("%d", &erasenum) == EOF && errno != 0)
+        {
+            fprintf(stderr, "scanf error\n");
+            exit(EXIT_FAILURE);
         }
         printf("\n");
-        if(erasenum == 0)
+        if (erasenum == 0)
             break;
         delete_entry(erasenum);
         printf("\n");

--- a/scores.c
+++ b/scores.c
@@ -236,7 +236,10 @@ int savescore(char *howdead, long score, int level, char *name)
         fclose(fp);
     }
     else
+    {
+        UNLOCK;
         err(1, "%s", "Error in savescore - fopen HISCOREPATH failed\n");
+    }
 
     UNLOCK;
     return output_value;

--- a/wand_head.h
+++ b/wand_head.h
@@ -11,8 +11,12 @@
                 /********** FILES ************/
 
 /* Change these to the necessary directories or files */
+#ifndef SCREENPATH
 #define SCREENPATH  "/usr/local/share/wanderer/screens"
+#endif
+#ifndef HISCOREPATH
 #define HISCOREPATH "/usr/local/share/wanderer/hiscore"
+#endif
 #define DICTIONARY  "/usr/share/dict/words"
 #define LOCKFILE    "/tmp/wanderer.lock"
 

--- a/wand_head.h
+++ b/wand_head.h
@@ -1,6 +1,6 @@
 /* file wand_head.h */
 
-#undef MSDOS /* Marina */
+#undef MSDOS                    /* Marina */
 
 #ifndef MSDOS
 #include <sys/file.h>
@@ -34,13 +34,13 @@
 /* #define NO_RESTORED_GAME_HISCORES  */
 /* #define COMPARE_BY_NAME  // define this to compare by name, not uid         */
 /* #define NO_ENCRYPTION // define this to disable the savefile encryptor */
-#define NOISY    /* do we want bells in the game ? */
+#define NOISY                   /* do we want bells in the game ? */
 
                 /****** OTHER PARAMETERS ******/
 
-#define GUESTUID 0    /* guestuid always compared by name         */
-#define EMSIZE 1024   /* size of editor moves memory              */
-#define ENTRIES 15    /* size of hiscore file                     */
+#define GUESTUID 0              /* guestuid always compared by name         */
+#define EMSIZE 1024             /* size of editor moves memory              */
+#define ENTRIES 15              /* size of hiscore file                     */
 
             /**** NOTHING TO CHANGE BELOW HERE ****/
 
@@ -48,15 +48,15 @@
 #ifdef        MSDOS
 #define        R_BIN        "rb"        /* binary mode for non-text files */
 #define        W_BIN        "wb"
-# ifdef        VOIDPTR
-#  define VOIDSTAR        (void *)
-# else
-#  define VOIDSTAR        (char *)
-# endif
-#define        ASKNAME                /* ask user's name if not in environment         */
-#define        COMPARE_BY_NAME        /* compare users with name, not uid                */
-#undef        getchar                /* remove stdio's definition to use curses'         */
-#define        getchar()        getch()        /* use curse's definition instead */
+#ifdef        VOIDPTR
+#define VOIDSTAR        (void *)
+#else
+#define VOIDSTAR        (char *)
+#endif
+#define        ASKNAME          /* ask user's name if not in environment         */
+#define        COMPARE_BY_NAME  /* compare users with name, not uid                */
+#undef        getchar           /* remove stdio's definition to use curses'         */
+#define        getchar()        getch() /* use curse's definition instead */
 
 #else /* not MSDOS */
 #define        R_BIN        "r"

--- a/wanderer.c
+++ b/wanderer.c
@@ -97,7 +97,7 @@ void show_credits(opt)
                 if (ch == 'q')
                     break;
                 move(maxlines + 2, 0);
-                addstr("          ");
+                printw("%10s", "");
                 refresh();
                 clear();
                 linecount = 0;

--- a/wanderer.c
+++ b/wanderer.c
@@ -31,6 +31,7 @@ char *edit_memory = NULL;
 char *memory_end = NULL;
 char screen_name[61];
 int record_file = -1;
+char *screenpath = NULL;
 
 /**/
 /***********************************
@@ -214,6 +215,18 @@ int main(int argc, char **argv)
     char *dead;
     char c;
 
+    // if found screens in current directory, then use it;
+    // otherwise, use SCREENPATH
+    screenpath = strdup("./screens");
+    sprintf(buffer, "%s/screen.1", screenpath);
+    if ((fp = open(buffer, O_RDONLY)) == -1)
+    {
+        free(screenpath);
+        screenpath = strdup(SCREENPATH);
+    }
+    else
+        close(fp);
+
     while ((c = getopt(argc, argv, "01k:et:r:fmCcvsi")) != -1)
     {
         switch (c)
@@ -230,7 +243,7 @@ int main(int argc, char **argv)
         case 'i':
             printf("\nWANDERER Copyright (C) 1988 S Shipway. Version %s.\n\n",
                    VERSION);
-            printf("Screens in %s.\n", SCREENPATH);
+            printf("Screens in %s.\n", screenpath);
             printf("Hiscore File %s.\n", HISCOREPATH);
             printf("Looking for Dictionary in %s.\n", DICTIONARY);
             printf("Lockfile for Scorefile %s.\n", LOCKFILE);
@@ -289,18 +302,18 @@ int main(int argc, char **argv)
     if (optind < argc)
         edit_screen = argv[optind];
 
-/* check for passwords - if file no_pws is in screen dir no pws! */
-    sprintf(buffer, "%s/no_pws", SCREENPATH);
+    /* check for passwords - if file no_pws is in screen dir no pws! */
+    sprintf(buffer, "%s/no_pws", screenpath);
     if ((fp = open(buffer, O_RDONLY)) != -1)
     {
         close(fp);
         no_passwords = 1;
     }
 
-/* count available screens */
+    /* count available screens */
     for (maxscreens = 0;; maxscreens++)
     {
-        sprintf(buffer, "%s/screen.%d", SCREENPATH, (maxscreens + 1));
+        sprintf(buffer, "%s/screen.%d", screenpath, (maxscreens + 1));
         if ((fp = open(buffer, O_RDONLY)) == -1)
             break;
         close(fp);
@@ -373,4 +386,5 @@ int main(int argc, char **argv)
     }
     if (record_file != -1)      /* Wouldn't it be better !to leave file open? */
         close(record_file);
+    free(screenpath);
 }

--- a/wanderer.c
+++ b/wanderer.c
@@ -23,33 +23,33 @@
 int debug_disp = 0;
 int no_passwords = 0;
 int maxscreens = 0;
-char screen[NOOFROWS][ROWLEN+1];
+char screen[NOOFROWS][ROWLEN + 1];
 int edit_mode = 0;
 int saved_game = 0;
 char *edit_screen = NULL;
 char *edit_memory = NULL;
 char *memory_end = NULL;
-char screen_name[61] ;
+char screen_name[61];
 int record_file = -1;
 
 /**/
 /***********************************
 *              readline            *
 ************************************/
-int readline(int fd,char *ptr,int max)
+int readline(int fd, char *ptr, int max)
 {
-  int count=0;
+    int count = 0;
 
-  while(read(fd,ptr,1)==1) 
-  {
-    if(++count==max)
-      break;
-    if(*ptr=='\n')
-      break;
-    ptr++;
-  }
-  *ptr='\0';
-  return count;
+    while (read(fd, ptr, 1) == 1)
+    {
+        if (++count == max)
+            break;
+        if (*ptr == '\n')
+            break;
+        ptr++;
+    }
+    *ptr = '\0';
+    return count;
 }
 
 /**************************************************
@@ -58,19 +58,20 @@ int readline(int fd,char *ptr,int max)
  * One for scrolling and one for paged Credits    *
  **************************************************/
 void show_credits(opt)
-        int opt;
+     int opt;
 {
-int maxlines, linecount;
-FILE *fp;
-char ch, buffer[100];
-fd_set inp;
-struct timeval tv;
+    int maxlines, linecount;
+    FILE *fp;
+    char ch, buffer[100];
+    fd_set inp;
+    struct timeval tv;
 
-    sprintf(buffer,"%s/credits",SCREENPATH);
-    if((fp = fopen(buffer,"r")) == NULL) {
+    sprintf(buffer, "%s/credits", SCREENPATH);
+    if ((fp = fopen(buffer, "r")) == NULL)
+    {
         printf("Sorry - credits unavailable!\n");
         exit(1);
-        }
+    }
     if (opt == PAGED)
     {
         initscr();
@@ -80,41 +81,49 @@ struct timeval tv;
     }
     linecount = 0;
     tv.tv_sec = 0;
-    tv.tv_usec = 500000L;  /* half second between scrolls */
-    while( fgets(buffer,100,fp) ) {
-            addstr(buffer);
-                if(opt == PAGED) {
-                if(++linecount == maxlines) {
-                        move(maxlines + 2,0);
-                        addstr("-- More --");
-                        refresh();
-                        ch = getch();
-                        if( ch == 'q' ) 
-                            break;
-                        move(maxlines + 2,0);
-                        addstr("          ");
-                        refresh();
-                        clear();
-                        linecount = 0;
-                }
-            } else { /* opt == SCROLLING */
-                printf("%s",buffer);
-                FD_ZERO(&inp);
-                FD_SET(0, &inp);
-                if (select(1,&inp,NULL,NULL,&tv) > 0) {
-                    if (read(0,&ch,1) == -1) {
-                        fprintf(stderr, "read error\n");
-                        exit(EXIT_FAILURE);
-                    }
-                    if(ch == 'q') 
-                        break;
-                }
+    tv.tv_usec = 500000L;       /* half second between scrolls */
+    while (fgets(buffer, 100, fp))
+    {
+        addstr(buffer);
+        if (opt == PAGED)
+        {
+            if (++linecount == maxlines)
+            {
+                move(maxlines + 2, 0);
+                addstr("-- More --");
+                refresh();
+                ch = getch();
+                if (ch == 'q')
+                    break;
+                move(maxlines + 2, 0);
+                addstr("          ");
+                refresh();
+                clear();
+                linecount = 0;
             }
+        }
+        else
+        {                       /* opt == SCROLLING */
+            printf("%s", buffer);
+            FD_ZERO(&inp);
+            FD_SET(0, &inp);
+            if (select(1, &inp, NULL, NULL, &tv) > 0)
+            {
+                if (read(0, &ch, 1) == -1)
+                {
+                    fprintf(stderr, "read error\n");
+                    exit(EXIT_FAILURE);
+                }
+                if (ch == 'q')
+                    break;
+            }
+        }
     }
-    if(opt == PAGED ) { /* Marina's changes - stdout blocked under curses */
+    if (opt == PAGED)
+    {                           /* Marina's changes - stdout blocked under curses */
         CBOFF;
         echo();
-        move(maxlines+2,0);
+        move(maxlines + 2, 0);
         refresh();
         endwin();
     }
@@ -128,23 +137,26 @@ struct timeval tv;
 ****************************************************************/
 char *get_name(void)
 {
-char *name;
+    char *name;
 
-    if((name = (char *)getenv("NEWNAME")) == NULL)
-        if((name = (char *)getenv("NAME")) == NULL)
-            if((name = (char *)getenv("FULLNAME")) == NULL)
-                if((name = (char *)getenv("USER")) == NULL)
-                    if((name = (char *)getenv("LOGNAME")) == NULL)
-#define ASKNAME /* Marina */
-#ifdef        ASKNAME        /* M001 */
+    if ((name = (char *) getenv("NEWNAME")) == NULL)
+        if ((name = (char *) getenv("NAME")) == NULL)
+            if ((name = (char *) getenv("FULLNAME")) == NULL)
+                if ((name = (char *) getenv("USER")) == NULL)
+                    if ((name = (char *) getenv("LOGNAME")) == NULL)
+#define ASKNAME                 /* Marina */
+#ifdef        ASKNAME           /* M001 */
                     {
-                        name = (char *)malloc(80);
-                        if (name == NULL) {
-                            printf("malloc error\n"); /* Replace with Err* */
+                        name = (char *) malloc(80);
+                        if (name == NULL)
+                        {
+                            printf("malloc error\n");   /* Replace with Err* */
                             exit(1);
                         }
-                        printf("Name? "); fflush(stdout);
-                        if (fgets(name,80,stdin) == NULL) { /* get rid of gets Marina*/
+                        printf("Name? ");
+                        fflush(stdout);
+                        if (fgets(name, 80, stdin) == NULL)
+                        {       /* get rid of gets Marina */
                             fprintf(stderr, "fgets error\n");
                             exit(EXIT_FAILURE);
                         }
@@ -152,9 +164,9 @@ char *name;
                             name = "noname";
                     }
 #else
-                    name = "noname";
+                        name = "noname";
 #endif
-    return(name);
+    return (name);
 }
 
 /**********************************************
@@ -164,173 +176,201 @@ char *name;
 char *get_keys()
 {
     char *keys = NULL;
-    if( ! keys ) {
-        if((keys = (char *)getenv("NEWKEYS")) == NULL)
-            {
-            keys = (char *)malloc(5);
-           strcpy(keys,"kjhl");
-            }
+    if (!keys)
+    {
+        if ((keys = (char *) getenv("NEWKEYS")) == NULL)
+        {
+            keys = (char *) malloc(5);
+            strcpy(keys, "kjhl");
+        }
     }
-    return(keys);
+    return (keys);
 }
 
 /**/
 /***************
 *  Why here ?  *
 ****************/
-extern int optind,opterr;
+extern int optind, opterr;
 extern char *optarg;
 
 /***************************************
 *  Main Program  -- Comment by Marina  *
 ****************************************/
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
-char (*frow)[ROWLEN+1] = screen;
-long score = 0;
-int fp;
-int num = 1;
-int bell = 0;
-int maxmoves = 0;
-int x;
-int y;
-char howdead[25];
-char buffer[100];
-char *name;
-char *keys;
-char *dead;
-char c; 
+    char (*frow)[ROWLEN + 1] = screen;
+    long score = 0;
+    int fp;
+    int num = 1;
+    int bell = 0;
+    int maxmoves = 0;
+    int x;
+    int y;
+    char howdead[25];
+    char buffer[100];
+    char *name;
+    char *keys;
+    char *dead;
+    char c;
 
-while(( c = getopt(argc,argv,"01k:et:r:fmCcvsi")) != -1 )
-{
-    switch(c) 
+    while ((c = getopt(argc, argv, "01k:et:r:fmCcvsi")) != -1)
     {
-        case '0': bell = 0; break;
-        case '1': bell = 1; break;
-        case 'k': keys = optarg; break;
-        case 'i': 
-                printf("\nWANDERER Copyright (C) 1988 S Shipway. Version %s.\n\n",VERSION);
-                printf("Screens in %s.\n",SCREENPATH);
-                printf("Hiscore File %s.\n",HISCOREPATH);
-                printf("Looking for Dictionary in %s.\n",DICTIONARY);
-                printf("Lockfile for Scorefile %s.\n",LOCKFILE);
-                exit(0);
-                break;
-        case 'm': erase_scores(); /* Need noecho() before rec passwd Marina */
-                exit(0);
-        case 'c': show_credits(PAGED);
-                exit(0);
-        case 'C': show_credits(SCROLLING);
-                exit(0);
-        case 's': 
-                savescore("-",-1,-1,"-"); /* savescore bug ! */
-                exit(0);
-        case 'f': debug_disp = 1; break;    /* Full screen mode */
-        case 'v': printf("\nWANDERER Copyright (C) 1988 S Shipway. Version %s.\n\n",VERSION);
-                exit (0);
+        switch (c)
+        {
+        case '0':
+            bell = 0;
+            break;
+        case '1':
+            bell = 1;
+            break;
+        case 'k':
+            keys = optarg;
+            break;
+        case 'i':
+            printf("\nWANDERER Copyright (C) 1988 S Shipway. Version %s.\n\n",
+                   VERSION);
+            printf("Screens in %s.\n", SCREENPATH);
+            printf("Hiscore File %s.\n", HISCOREPATH);
+            printf("Looking for Dictionary in %s.\n", DICTIONARY);
+            printf("Lockfile for Scorefile %s.\n", LOCKFILE);
+            exit(0);
+            break;
+        case 'm':
+            erase_scores();     /* Need noecho() before rec passwd Marina */
+            exit(0);
+        case 'c':
+            show_credits(PAGED);
+            exit(0);
+        case 'C':
+            show_credits(SCROLLING);
+            exit(0);
+        case 's':
+            savescore("-", -1, -1, "-");        /* savescore bug ! */
+            exit(0);
+        case 'f':
+            debug_disp = 1;
+            break;              /* Full screen mode */
+        case 'v':
+            printf("\nWANDERER Copyright (C) 1988 S Shipway. Version %s.\n\n",
+                   VERSION);
+            exit(0);
         case 'r':
-                if((record_file = open(optarg,O_WRONLY|O_CREAT,0600))==-1) {
-                        printf("Cannot open file %s for recording.\n",optarg);
-                    exit(-1);
-                }
-                break;
-        case 'e': edit_mode = 1;
-                 no_passwords = 1;
-                memory_end = edit_memory = (char *)malloc(EMSIZE * sizeof(char));
-                break;
-        case 't': edit_screen = optarg;
-                debug_disp = edit_mode = 1;
-                rscreen(0,&maxmoves);
-                initscr();
-                map(frow);
-                check_legality();
-                move(21,0); refresh();
-                endwin();
-                exit(0);
-        default: fprintf(stderr,"Usage: %s [ -e | -m | -C | -c | -s | [ -r file ] [ -f ] | -t file ] [ -0 | -1 ] [ -i ] [ -k keys ] [ file ]\n",argv[0]);
-        exit(1);
+            if ((record_file = open(optarg, O_WRONLY | O_CREAT, 0600)) == -1)
+            {
+                printf("Cannot open file %s for recording.\n", optarg);
+                exit(-1);
+            }
+            break;
+        case 'e':
+            edit_mode = 1;
+            no_passwords = 1;
+            memory_end = edit_memory = (char *) malloc(EMSIZE * sizeof(char));
+            break;
+        case 't':
+            edit_screen = optarg;
+            debug_disp = edit_mode = 1;
+            rscreen(0, &maxmoves);
+            initscr();
+            map(frow);
+            check_legality();
+            move(21, 0);
+            refresh();
+            endwin();
+            exit(0);
+        default:
+            fprintf(stderr,
+                    "Usage: %s [ -e | -m | -C | -c | -s | [ -r file ] [ -f ] | -t file ] [ -0 | -1 ] [ -i ] [ -k keys ] [ file ]\n",
+                    argv[0]);
+            exit(1);
         }
     }
 
-if( optind < argc ) edit_screen = argv[optind];
+    if (optind < argc)
+        edit_screen = argv[optind];
 
 /* check for passwords - if file no_pws is in screen dir no pws! */
-sprintf(buffer,"%s/no_pws",SCREENPATH);
-if((fp = open(buffer,O_RDONLY)) != -1) {
-    close(fp);
-    no_passwords = 1;
-}
+    sprintf(buffer, "%s/no_pws", SCREENPATH);
+    if ((fp = open(buffer, O_RDONLY)) != -1)
+    {
+        close(fp);
+        no_passwords = 1;
+    }
 
 /* count available screens */
-for(maxscreens = 0;;maxscreens++) {
-    sprintf(buffer,"%s/screen.%d",SCREENPATH,(maxscreens+1));
-    if((fp = open(buffer, O_RDONLY)) == -1 )
-        break;
-    close(fp);
-} 
+    for (maxscreens = 0;; maxscreens++)
+    {
+        sprintf(buffer, "%s/screen.%d", SCREENPATH, (maxscreens + 1));
+        if ((fp = open(buffer, O_RDONLY)) == -1)
+            break;
+        close(fp);
+    }
 
-name=get_name();  /* M */
-keys=get_keys();  /* M */
-initscr();
+    name = get_name();          /* M */
+    keys = get_keys();          /* M */
+    initscr();
 
 /* MAIN PROGRAM HERE */
 
-CBON; noecho();
+    CBON;
+    noecho();
 
-if(!edit_mode) {
-        for (;;num++) {
-            if (rscreen(num,&maxmoves)) 
+    if (!edit_mode)
+    {
+        for (;; num++)
+        {
+            if (rscreen(num, &maxmoves))
             {
-                strcpy(howdead,"a non-existant screen");
+                strcpy(howdead, "a non-existant screen");
                 break;
-                }
-            dead = playscreen(&num,&score,&bell,maxmoves,keys);
-            if ((dead != NULL) && (*dead == '~')) 
+            }
+            dead = playscreen(&num, &score, &bell, maxmoves, keys);
+            if ((dead != NULL) && (*dead == '~'))
             {
-                num = (int)(dead[1]) - 1;
+                num = (int) (dead[1]) - 1;
                 dead = NULL;
             }
             if (dead != NULL)
             {
-                strcpy(howdead,dead);
+                strcpy(howdead, dead);
                 break;
             }
         }
     }
-else
+    else
     {
-    if(rscreen(num,&maxmoves))
+        if (rscreen(num, &maxmoves))
         {
-        for(x=0;x<ROWLEN;x++)
-            for(y=0;y<NOOFROWS;y++)
-                screen[y][x] =  ' ';
+            for (x = 0; x < ROWLEN; x++)
+                for (y = 0; y < NOOFROWS; y++)
+                    screen[y][x] = ' ';
         }
-    editscreen(num,&score,&bell,maxmoves,keys);
+        editscreen(num, &score, &bell, maxmoves, keys);
     }
 /* END OF MAIN PROGRAM */
 
 /****************************
 *  SAVE ROUTINES FOR SCORES * 
 *****************************/
-    if(!edit_mode)
+    if (!edit_mode)
     {
         getch();
         echo();
         refresh();
         endwin();
-        printf("%s killed by %s with a score of %ld on level %d.\n",
-                                            name,howdead,score,num); 
+        printf("%s killed by %s with a score of %ld on level %d.\n", name,
+               howdead, score, num);
         printf("\nWANDERER (C)1988 S. Shipway\n");
-        if((savescore(howdead,score,num,name) == 0)&&(score != 0))
-            printf("\nWARNING: %s : score not saved!\n",argv[0]);
+        if ((savescore(howdead, score, num, name) == 0) && (score != 0))
+            printf("\nWARNING: %s : score not saved!\n", argv[0]);
     }
     else
-    { /* Still need to clean up screen, yes ? Marina */
-        
+    {                           /* Still need to clean up screen, yes ? Marina */
+
         echo();
         refresh();
         endwin();
     }
-    if(record_file != -1)/* Wouldn't it be better !to leave file open?*/
+    if (record_file != -1)      /* Wouldn't it be better !to leave file open? */
         close(record_file);
 }


### PR DESCRIPTION
I took the liberty of choosing the style since several mixed even in one file.

The most important probably is the installation process, now it can be installed in any path. Also, it can read screens, which actually take priority, so no need to install. `./wanderer -i` can check the paths. As for such feature, `SCREENPATH` and `HISCOREPATH` can also be specified in `make`, although it should be no need with `PREFIX`.

The rest is minor changes.
